### PR TITLE
Add Nix devShell and auto versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@
 # Nix
 result
 
+# Nix devShell
+compile_commands.json
+.cache
+
 # Meson
 meson-out
 meson-info

--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ Refer to the [Hyprland wiki](https://wiki.hyprland.org/Nix/Hyprland-on-Home-Mana
   inputs = {
     # Hyprland is **such** eye candy
     hyprland ={
-      # Update for releavant commit, this is just bleeding edge as of 2024/04/11
-      url = github:hyprwm/Hyprland/ac0f3411c18497a39498b756b711e092512de9e0;
+      url = "github:hyprwm/Hyprland";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     Hyprspace = {
-      url = github:KZDKM/Hyprspace;
+      url = "github:KZDKM/Hyprspace";
+
+      # Hyprspace uses latest Hyprland. We declare this to keep them in sync.
       inputs.hyprland.follows = "hyprland";
     };
   };

--- a/flake.lock
+++ b/flake.lock
@@ -78,31 +78,6 @@
         "type": "github"
       }
     },
-    "hyprlandPlugins": {
-      "inputs": {
-        "hyprland": [
-          "hyprland"
-        ],
-        "systems": [
-          "hyprlandPlugins",
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1713283897,
-        "narHash": "sha256-/0OPK/bDr8/Lf7r8kzDD/yP1kySbJ8gPmV3CdUbVTFM=",
-        "owner": "hyprwm",
-        "repo": "hyprland-plugins",
-        "rev": "00d147d7f6ad2ecfbf75efe4a8402723c72edd98",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-plugins",
-        "type": "github"
-      }
-    },
     "hyprlang": {
       "inputs": {
         "nixpkgs": [
@@ -146,8 +121,7 @@
     },
     "root": {
       "inputs": {
-        "hyprland": "hyprland",
-        "hyprlandPlugins": "hyprlandPlugins"
+        "hyprland": "hyprland"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -40,17 +40,16 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1712835979,
-        "narHash": "sha256-m44SvLfwPc8qPpBQa5ObOtTe6RbVNfQLpn+bCdlHFxQ=",
+        "lastModified": 1713376910,
+        "narHash": "sha256-6cvw+CxacXe+l8/mZ1+ih21vLHvhIC+Erc7LQF0dyrQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "185a3b48814cc4a1afbf32a69792a6161c4038cd",
+        "rev": "82222342f10a7eff0ec9be972153e740d0f95213",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "185a3b48814cc4a1afbf32a69792a6161c4038cd",
         "type": "github"
       }
     },
@@ -173,20 +172,18 @@
     "wlroots": {
       "flake": false,
       "locked": {
-        "host": "gitlab.freedesktop.org",
-        "lastModified": 1709983277,
-        "narHash": "sha256-wXWIJLd4F2JZeMaihWVDW/yYXCLEC8OpeNJZg9a9ly8=",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
-        "type": "gitlab"
+        "lastModified": 1713124002,
+        "narHash": "sha256-vPeZCY+sdiGsz4fl3AVVujfyZyQBz6+vZdkUE4hQ+HI=",
+        "owner": "hyprwm",
+        "repo": "wlroots-hyprland",
+        "rev": "611a4f24cd2384378f6e500253983107c6656c64",
+        "type": "github"
       },
       "original": {
-        "host": "gitlab.freedesktop.org",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
-        "type": "gitlab"
+        "owner": "hyprwm",
+        "repo": "wlroots-hyprland",
+        "rev": "611a4f24cd2384378f6e500253983107c6656c64",
+        "type": "github"
       }
     },
     "xdph": {

--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712836056,
-        "narHash": "sha256-qf6yev9OlJuQv557ApLQ/5V8pQj0YOO9tyh5j3It1mY=",
+        "lastModified": 1713283897,
+        "narHash": "sha256-/0OPK/bDr8/Lf7r8kzDD/yP1kySbJ8gPmV3CdUbVTFM=",
         "owner": "hyprwm",
         "repo": "hyprland-plugins",
-        "rev": "e9457e08ca3ff16dc5a815be62baf9e18b539197",
+        "rev": "00d147d7f6ad2ecfbf75efe4a8402723c72edd98",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,7 @@
     "root": {
       "inputs": {
         "hyprland": "hyprland",
-        "hyprlandPlugins": "hyprlandPlugins",
-        "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ]
+        "hyprlandPlugins": "hyprlandPlugins"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,19 @@
 {
   description = "Hyprspace";
 
-  # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.follows = "hyprland/nixpkgs";
+  inputs = {
+    nixpkgs.follows = "hyprland/nixpkgs";
 
-  inputs.hyprland = {
-    url = github:hyprwm/Hyprland/185a3b48814cc4a1afbf32a69792a6161c4038cd;
-  };
-  inputs.hyprlandPlugins = {
-    url = "github:hyprwm/hyprland-plugins";
-    inputs.hyprland.follows = "hyprland";
+    hyprland = {
+      type = "github";
+      owner = "hyprwm";
+      repo = "Hyprland";
+    };
+
+    hyprlandPlugins = {
+      url = "github:hyprwm/hyprland-plugins";
+      inputs.hyprland.follows = "hyprland";
+    };
   };
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,7 @@
 {
   description = "Hyprspace";
 
-  inputs = {
-    hyprland = {
-      type = "github";
-      owner = "hyprwm";
-      repo = "Hyprland";
-    };
-  };
+  inputs.hyprland.url = "github:hyprwm/Hyprland";
 
   outputs = {
     self,
@@ -24,9 +18,21 @@
       in
         attrs system pkgs);
 
-    version = "0.1";
+    # Generate version
+    inherit (builtins) elemAt head readFile split substring;
+    mkDate = longDate: (lib.concatStringsSep "-" [
+      (substring 0 4 longDate)
+      (substring 4 2 longDate)
+      (substring 6 2 longDate)
+    ]);
+    version =
+      (head (split "'"
+        (elemAt
+          (split " version: '" (readFile ./meson.build))
+          2)))
+      + "+date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
   in {
-    # Provide some binary packages for selected system types.
+    # Provide some binary packages for selected system types
     packages = perSystem (system: pkgs: {
       Hyprspace = let
         hyprlandPkg = hyprland.packages.${system}.hyprland;

--- a/flake.nix
+++ b/flake.nix
@@ -84,5 +84,21 @@
           nixpkgs.overlays = self.overlays;
           environment.systemPackages = [ pkgs.Hyprspace ];
         };
+
+      devShells = forAllSystems (system: {
+        default = pkgsFor.${system}.mkShell {
+          shellHook = ''
+            meson setup build --reconfigure
+            sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
+          '';
+          name = "Hyprspace-shell";
+          nativeBuildInputs = with pkgsFor.${system}; [gcc13];
+          buildInputs = [hyprland.packages.${system}.hyprland];
+          inputsFrom = [
+            hyprland.packages.${system}.hyprland
+            self.packages.${system}.Hyprspace
+          ];
+        };
+      });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,93 +12,97 @@
     inputs.hyprland.follows = "hyprland";
   };
 
-  outputs = { self, nixpkgs, hyprland, hyprlandPlugins }:
-    let
-      # System types to support.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      # Nixpkgs instantiated for supported system types.
-      pkgsFor = forAllSystems (system:
-        import nixpkgs {
-          localSystem.system = system;
-          overlays = with self.overlays; [ hyprland-plugins ];
-        });
+  outputs = {
+    self,
+    nixpkgs,
+    hyprland,
+    hyprlandPlugins,
+  }: let
+    # System types to support.
+    supportedSystems = ["x86_64-linux" "aarch64-linux"];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    # Nixpkgs instantiated for supported system types.
+    pkgsFor = forAllSystems (system:
+      import nixpkgs {
+        localSystem.system = system;
+        overlays = with self.overlays; [hyprland-plugins];
+      });
 
-      version = "0.1";
-      mkHyprlandPlugin = hyprlandPlugins.overlays.mkHyprlandPlugin;
-      lib = nixpkgs.lib;
-    in
+    version = "0.1";
+    mkHyprlandPlugin = hyprlandPlugins.overlays.mkHyprlandPlugin;
+    lib = nixpkgs.lib;
+  in {
+    overlays = {
+      default = self.overlays.hyprland-plugins.Hyprspace;
+      hyprland-plugins = lib.composeManyExtensions [
+        mkHyprlandPlugin
+        (final: prev: let
+          inherit (final) callPackage;
+        in {
+          Hyprspace =
+            callPackage
+            ({
+              lib,
+              hyprland,
+              hyprlandPlugins,
+            }:
+              hyprlandPlugins.mkHyprlandPlugin {
+                pluginName = "Hyprspace";
+                inherit version;
+                src = ./.;
 
-    {
-      overlays = {
-        default = self.overlays.hyprland-plugins.Hyprspace;
-        hyprland-plugins = lib.composeManyExtensions [
-          mkHyprlandPlugin
-          (final: prev:
-            let
-              inherit (final) callPackage;
-            in
-            {
-              Hyprspace = callPackage
-                ({ lib
-                 , hyprland
-                 , hyprlandPlugins
-                 }:
-                  hyprlandPlugins.mkHyprlandPlugin {
-                    pluginName = "Hyprspace";
-                    inherit version;
-                    src = ./.;
+                inherit (hyprland) nativeBuildInputs;
 
-                    inherit (hyprland) nativeBuildInputs;
+                meta = with lib; {
+                  homepage = "https://github.com/KZDKM/Hyprspace";
+                  description = "Workspace overview plugin for Hyprland";
+                  license = licenses.gpl2Only;
+                  platforms = platforms.linux;
+                };
+              })
+            {};
+        })
+      ];
+    };
 
-                    meta = with lib; {
-                      homepage = "https://github.com/KZDKM/Hyprspace";
-                      description = "Workspace overview plugin for Hyprland";
-                      license = licenses.gpl2Only;
-                      platforms = platforms.linux;
-                    };
-                  })
-                { };
-            })
+    # Provide some binary packages for selected system types.
+    packages =
+      forAllSystems
+      (system: {
+        inherit (pkgsFor.${system}) Hyprspace;
+      });
+
+    # The default package for 'nix build'. This makes sense if the
+    # flake provides only one package or there is a clear "main"
+    # package.
+    defaultPackage =
+      forAllSystems
+      (system: self.packages.${system}.Hyprspace);
+
+    # A NixOS module
+    # TODO: Pass in configuration options.
+    nixosModules.Hyprspace = {pkgs, ...}: {
+      nixpkgs.overlays = self.overlays;
+      environment.systemPackages = [pkgs.Hyprspace];
+    };
+
+    # The default environment for 'nix develop'
+    devShells = forAllSystems (system: {
+      default = pkgsFor.${system}.mkShell {
+        shellHook = ''
+          meson setup build --reconfigure
+          sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
+        '';
+        name = "Hyprspace-shell";
+        nativeBuildInputs = with pkgsFor.${system}; [gcc13];
+        buildInputs = [hyprland.packages.${system}.hyprland];
+        inputsFrom = [
+          hyprland.packages.${system}.hyprland
+          self.packages.${system}.Hyprspace
         ];
       };
+    });
 
-      # Provide some binary packages for selected system types.
-      packages = forAllSystems
-        (system:
-          {
-            inherit (pkgsFor.${system}) Hyprspace;
-          });
-
-      # The default package for 'nix build'. This makes sense if the
-      # flake provides only one package or there is a clear "main"
-      # package.
-      defaultPackage = forAllSystems
-        (system: self.packages.${system}.Hyprspace);
-
-      # A NixOS module
-      # TODO: Pass in configuration options.
-      nixosModules.Hyprspace =
-        { pkgs, ... }:
-        {
-          nixpkgs.overlays = self.overlays;
-          environment.systemPackages = [ pkgs.Hyprspace ];
-        };
-
-      devShells = forAllSystems (system: {
-        default = pkgsFor.${system}.mkShell {
-          shellHook = ''
-            meson setup build --reconfigure
-            sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
-          '';
-          name = "Hyprspace-shell";
-          nativeBuildInputs = with pkgsFor.${system}; [gcc13];
-          buildInputs = [hyprland.packages.${system}.hyprland];
-          inputsFrom = [
-            hyprland.packages.${system}.hyprland
-            self.packages.${system}.Hyprspace
-          ];
-        };
-      });
-    };
+    formatter = forAllSystems (system: pkgsFor.${system}.alejandra);
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -74,21 +74,8 @@
       forAllSystems
       (system: {
         inherit (pkgsFor.${system}) Hyprspace;
+        default = self.packages.${system}.Hyprspace;
       });
-
-    # The default package for 'nix build'. This makes sense if the
-    # flake provides only one package or there is a clear "main"
-    # package.
-    defaultPackage =
-      forAllSystems
-      (system: self.packages.${system}.Hyprspace);
-
-    # A NixOS module
-    # TODO: Pass in configuration options.
-    nixosModules.Hyprspace = {pkgs, ...}: {
-      nixpkgs.overlays = self.overlays;
-      environment.systemPackages = [pkgs.Hyprspace];
-    };
 
     # The default environment for 'nix develop'
     devShells = forAllSystems (system: {


### PR DESCRIPTION
I did a few Nix things in this PR:

1. Added a devShell to make contributing from Nix way easier.
2. Added a formatter for Nix code because the previous one wasn't declared.
3. Made the Nix code more up to date to support things like `<flake>.packages.<system>.default`.
4. Remove the Nix dependency on hyprland-plugins.
5. Automated the nix side versioning of the package so when the version does change in `meson.build`, it won't have to be changed in the flake as well.
6. Updated the flake.lock

This is kind of an opinionated refactor for most of it but I kinda had to to improve readability.