### PR TITLE
Workspace BorderBox Pleacement Fixup!

### DIFF
--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -115,7 +115,7 @@ void CHyprspaceWidget::draw() {
     // Panel Border
      if (Config::panelBorderWidth > 0) {
         // Border box
-        CBox borderBox = {owner->vecPosition.x, owner->vecPosition.y + Config::panelHeight - curYOffset.value(), owner->vecTransformedSize.x, (Config::panelBorderWidth) * owner->scale};
+        CBox borderBox = {owner->vecPosition.x, owner->vecPosition.y + Config::panelHeight + Config::reservedArea - curYOffset.value(), owner->vecTransformedSize.x, (Config::panelBorderWidth) * owner->scale};
         if (Config::onBottom) borderBox = {owner->vecPosition.x, owner->vecPosition.y + owner->vecTransformedSize.y - ((Config::panelHeight + Config::reservedArea) * owner->scale) + curYOffset.value(), owner->vecTransformedSize.x, (Config::panelBorderWidth) * owner->scale};
 
         g_pHyprRenderer->damageBox(&borderBox);


### PR DESCRIPTION
 -> borderBox: Account for reservedArea (fix border placement)
 
 CBox Border Box isn't accounting for reservedArea: which in turn causes the border to be offset (above) by the size of reservedArea. Like so:
 
![2024-04-22_10-49](https://github.com/KZDKM/Hyprspace/assets/20159346/6c2c05fe-d57d-4f05-8b1e-d281c5c54c6b)

Ensure that Config::reservedArea is added and accounted for in Cbox BorderBox to fix it.