### PR TITLE
Workspace BorderBox Placement Fixup!

### DIFF
--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -115,7 +115,7 @@ void CHyprspaceWidget::draw() {
     // Panel Border
      if (Config::panelBorderWidth > 0) {
         // Border box
-        CBox borderBox = {owner->vecPosition.x, owner->vecPosition.y + Config::panelHeight - curYOffset.value(), owner->vecTransformedSize.x, (Config::panelBorderWidth) * owner->scale};
+        CBox borderBox = {owner->vecPosition.x, owner->vecPosition.y + Config::panelHeight + Config::reservedArea - curYOffset.value(), owner->vecTransformedSize.x, (Config::panelBorderWidth) * owner->scale};
         if (Config::onBottom) borderBox = {owner->vecPosition.x, owner->vecPosition.y + owner->vecTransformedSize.y - ((Config::panelHeight + Config::reservedArea) * owner->scale) + curYOffset.value(), owner->vecTransformedSize.x, (Config::panelBorderWidth) * owner->scale};
 
         g_pHyprRenderer->damageBox(&borderBox);


### PR DESCRIPTION
 -> borderBox: Account for reservedArea (fix border placement)
 
 CBox borderBox doesn't account for reservedArea, resulting in an offset/misplacement:
 
![2024-04-22_10-49](https://github.com/KZDKM/Hyprspace/assets/20159346/a8b91f7a-27ef-41cb-98cd-41a889436934)

Fix this by adding  Config::reservedArea