### PR TITLE
fix build and crashes on hyprland 0.40.0

### DIFF
--- a/src/Overview.cpp
+++ b/src/Overview.cpp
@@ -52,13 +52,13 @@ void CHyprspaceWidget::show() {
     if (oLayerAlpha.empty() && Config::hideRealLayers) {
         for (auto& ls : owner->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
             //ls->startAnimation(false);
-            oLayerAlpha.emplace_back(std::make_tuple(ls.get(), ls->alpha.goal()));
+            oLayerAlpha.emplace_back(std::make_tuple(ls, ls->alpha.goal()));
             ls->alpha = 0.f;
             ls->fadingOut = true;
         }
         for (auto& ls : owner->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
             //ls->startAnimation(false);
-            oLayerAlpha.emplace_back(std::make_tuple(ls.get(), ls->alpha.goal()));
+            oLayerAlpha.emplace_back(std::make_tuple(ls, ls->alpha.goal()));
             ls->alpha = 0.f;
             ls->fadingOut = true;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,20 +57,20 @@ int hyprsplitNumWorkspaces = -1;
 
 // casual breaking change upstream screwed the entire thing up
 // API stability my ass
-CSharedPointer<HOOK_CALLBACK_FN> g_pRenderHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pConfigReloadHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pOpenLayerHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pCloseLayerHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pMouseButtonHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pMouseAxisHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pTouchDownHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pTouchUpHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pSwipeBeginHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pSwipeUpdateHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pSwipeEndHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pKeyPressHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pSwitchWorkspaceHook;
-CSharedPointer<HOOK_CALLBACK_FN> g_pAddMonitorHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pRenderHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pConfigReloadHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pOpenLayerHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pCloseLayerHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pMouseButtonHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pMouseAxisHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pTouchDownHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pTouchUpHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pSwipeBeginHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pSwipeUpdateHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pSwipeEndHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pKeyPressHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pSwitchWorkspaceHook;
+std::shared_ptr<HOOK_CALLBACK_FN> g_pAddMonitorHook;
 
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;


### PR DESCRIPTION
Hello! Noticed that this plugin fails to build on 0.40.0, so I changed some types to make it compile. But then I noticed that it crashes on hiding the widget, so I fixed it as well. Should fix [#38](https://github.com/KZDKM/Hyprspace/issues/38)