### PR TITLE
Fix mouse input in scaled multi-monitor configurations

### DIFF
--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -20,7 +20,7 @@ bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
     for (auto& w : workspaceBoxes) {
         auto wi = std::get<0>(w);
         auto wb = std::get<1>(w);
-        if (wb.containsPoint(coords * getOwner()->scale)) {
+        if (wb.containsPoint(coords)) {
             targetWorkspaceID = wi;
             break;
         }

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -299,7 +299,14 @@ void CHyprspaceWidget::draw() {
                 }
         }
 
-        // resets workspaceBox to absolute position for input detection
+        // Resets workspaceBox to scaled absolute coordinates for input detection.
+        // While rendering is done in pixel coordinates, input detection is done in
+        // scaled coordinates, taking into account monitor scaling.
+        // Since the monitor position is already given in scaled coordinates,
+        // we only have to scale all relative coordinates, then add them to the
+        // monitor position to get a scaled absolute position.
+        curWorkspaceBox.scale(1 / owner->scale);
+
         curWorkspaceBox.x += owner->vecPosition.x;
         curWorkspaceBox.y += owner->vecPosition.y;
         workspaceBoxes.emplace_back(std::make_tuple(wsID, curWorkspaceBox));


### PR DESCRIPTION
This resolves an issue where mouse input coordinates are not translated correctly when using a multi-monitor setup with display scaling applied, which would lead to mouse click events being forwarded to the wrong workspace box.

It now works correctly even when mixed scaling is applied to different monitors.