### PR TITLE
nix: Include meson in nativeBuildInputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "aquamarine": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1724006173,
+        "narHash": "sha256-1ROh0buuxiMyc6eIb3CIbJsmYO7PhLqSYs55mOx1XTk=",
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "rev": "7f8df01d4297b9068a9592400f16044602844f86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "aquamarine",
+        "type": "github"
+      }
+    },
     "hyprcursor": {
       "inputs": {
         "hyprlang": [
@@ -16,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718368322,
-        "narHash": "sha256-VfMg3RsnRLQzbq0hFIh1dCM09b5C/F/qPFUOgU/CRi0=",
+        "lastModified": 1722623071,
+        "narHash": "sha256-sLADpVgebpCBFXkA1FlCXtvEPu1tdEsTfqK1hfeHySE=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "dd3a853c8239d1c3f3f37de7d2b8ae4b4f3840df",
+        "rev": "912d56025f03d41b1ad29510c423757b4379eb1c",
         "type": "github"
       },
       "original": {
@@ -31,6 +64,7 @@
     },
     "hyprland": {
       "inputs": {
+        "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
@@ -40,11 +74,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1718550250,
-        "narHash": "sha256-RE3xo3nLrWzc3LZ/KeZBwbPWYK2c62bl45ryOYJYe5o=",
+        "lastModified": 1724274303,
+        "narHash": "sha256-c2jNOqidh5lLX+uwjHgceFuKVJbqavDPoSS3PqLFj+U=",
         "ref": "refs/heads/main",
-        "rev": "d0a6fa7aa6c3a9d94611130a9213de19a8754d67",
-        "revCount": 4845,
+        "rev": "cae937c51bd220d6676c6027d05ea51fc3c821bb",
+        "revCount": 5123,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -69,11 +103,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691753796,
-        "narHash": "sha256-zOEwiWoXk3j3+EoF3ySUJmberFewWlagvewDRuWYAso=",
+        "lastModified": 1721326555,
+        "narHash": "sha256-zCu4R0CSHEactW9JqYki26gy8h9f6rHmSwj4XJmlHgg=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "0c2ce70625cb30aef199cb388f99e19a61a6ce03",
+        "rev": "5a11232266bf1a1f5952d5b179c3f4b2facaaa84",
         "type": "github"
       },
       "original": {
@@ -98,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717881852,
-        "narHash": "sha256-XeeVoKHQgfKuXoP6q90sUqKyl7EYy3ol2dVZGM+Jj94=",
+        "lastModified": 1721324361,
+        "narHash": "sha256-BiJKO0IIdnSwHQBSrEJlKlFr753urkLE48wtt0UhNG4=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "ec6938c66253429192274d612912649a0cfe4d28",
+        "rev": "adbefbf49664a6c2c8bf36b6487fd31e3eb68086",
         "type": "github"
       },
       "original": {
@@ -123,11 +157,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718271409,
-        "narHash": "sha256-8KvVqtApNt4FWTdn1TqVvw00rpqyG9UuUPA2ilPVD1U=",
+        "lastModified": 1722869141,
+        "narHash": "sha256-0KU4qhyMp441qfwbirNg3+wbm489KnEjXOz2I/RbeFs=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "8e10e0626fb26a14b859b3811b6ed7932400c86e",
+        "rev": "0252fd13e78e60fb0da512a212e56007515a49f7",
         "type": "github"
       },
       "original": {
@@ -148,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718119275,
-        "narHash": "sha256-nqDYXATNkyGXVmNMkT19fT4sjtSPBDS1LLOxa3Fueo4=",
+        "lastModified": 1721324119,
+        "narHash": "sha256-SOOqIT27/X792+vsLSeFdrNTF+OSRp5qXv6Te+fb2Qg=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "1419520d5f7f38d35e05504da5c1b38212a38525",
+        "rev": "a048a6cb015340bd82f97c1f40a4b595ca85cc30",
         "type": "github"
       },
       "original": {
@@ -163,11 +197,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718318537,
-        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
+        "lastModified": 1723637854,
+        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
+        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
         "type": "github"
       },
       "original": {
@@ -214,11 +248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718272114,
-        "narHash": "sha256-KsX7sAwkEFpXiwyjt0HGTnnrUU58wW1jlzj5IA/LRz8=",
+        "lastModified": 1722365976,
+        "narHash": "sha256-Khdm+mDzYA//XaU0M+hftod+rKr5q9SSHSEuiQ0/9ow=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "24be4a26f0706e456fca1b61b8c79f7486a9e86d",
+        "rev": "7f2a77ddf60390248e2a3de2261d7102a13e5341",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,82 +3,89 @@
 
   inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
 
-  outputs = {
-    self,
-    hyprland,
-    ...
-  }: let
-    inherit (builtins) elemAt head readFile split substring;
-    inherit (hyprland.inputs) nixpkgs;
-    inherit (nixpkgs) lib;
+  outputs =
+    { self, hyprland, ... }:
+    let
+      inherit (builtins)
+        elemAt
+        head
+        readFile
+        split
+        substring
+        ;
+      inherit (hyprland.inputs) nixpkgs;
+      inherit (nixpkgs) lib;
 
-    # System types to support.
-    supportedSystems = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+      # System types to support.
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
 
-    perSystem = attrs:
-      lib.genAttrs supportedSystems (system:
-        attrs system nixpkgs.legacyPackages.${system});
+      perSystem = attrs: lib.genAttrs supportedSystems (system: attrs system nixpkgs.legacyPackages.${system});
 
-    # Generate version
-    mkDate = longDate: (lib.concatStringsSep "-" [
-      (substring 0 4 longDate)
-      (substring 4 2 longDate)
-      (substring 6 2 longDate)
-    ]);
+      # Generate version
+      mkDate =
+        longDate:
+        (lib.concatStringsSep "-" [
+          (substring 0 4 longDate)
+          (substring 4 2 longDate)
+          (substring 6 2 longDate)
+        ]);
 
-    version =
-      (head (split "'"
-        (elemAt
-          (split " version: '" (readFile ./meson.build))
-          2)))
-      + "+date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
-  in {
-    # Provide some binary packages for selected system types
-    packages = perSystem (system: pkgs: {
-      Hyprspace = let
-        hyprlandPkg = hyprland.packages.${system}.hyprland;
-      in
-        pkgs.gcc13Stdenv.mkDerivation {
-          pname = "Hyprspace";
-          inherit version;
-          src = ./.;
+      version =
+        (head (split "'" (elemAt (split " version: '" (readFile ./meson.build)) 2)))
+        + "+date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
+    in
+    {
+      # Provide some binary packages for selected system types
+      packages = perSystem (
+        system: pkgs: {
+          Hyprspace =
+            let
+              hyprlandPkg = hyprland.packages.${system}.hyprland;
+            in
+            pkgs.gcc13Stdenv.mkDerivation {
+              pname = "Hyprspace";
+              inherit version;
+              src = ./.;
 
-          inherit (hyprlandPkg) nativeBuildInputs;
-          buildInputs = [hyprlandPkg] ++ hyprlandPkg.buildInputs;
-          dontUseCmakeConfigure = true;
+              nativeBuildInputs = hyprlandPkg.nativeBuildInputs ++ [ pkgs.meson ];
+              buildInputs = [ hyprlandPkg ] ++ hyprlandPkg.buildInputs;
+              dontUseCmakeConfigure = true;
 
-          meta = with lib; {
-            homepage = "https://github.com/KZDKM/Hyprspace";
-            description = "Workspace overview plugin for Hyprland";
-            license = licenses.gpl2Only;
-            platforms = platforms.linux;
+              meta = with lib; {
+                homepage = "https://github.com/KZDKM/Hyprspace";
+                description = "Workspace overview plugin for Hyprland";
+                license = licenses.gpl2Only;
+                platforms = platforms.linux;
+              };
+            };
+          default = self.packages.${system}.Hyprspace;
+        }
+      );
+
+      # The default environment for 'nix develop'
+      devShells = perSystem (
+        system: pkgs: {
+          default = pkgs.mkShell {
+            name = "Hyprspace-shell";
+
+            nativeBuildInputs = with pkgs; [ gcc13 ];
+            buildInputs = [ hyprland.packages.${system}.hyprland ];
+            inputsFrom = [
+              hyprland.packages.${system}.hyprland
+              self.packages.${system}.Hyprspace
+            ];
+
+            shellHook = ''
+              meson setup build --reconfigure
+              sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
+            '';
           };
-        };
-      default = self.packages.${system}.Hyprspace;
-    });
+        }
+      );
 
-    # The default environment for 'nix develop'
-    devShells = perSystem (system: pkgs: {
-      default = pkgs.mkShell {
-        name = "Hyprspace-shell";
-
-        nativeBuildInputs = with pkgs; [gcc13];
-        buildInputs = [hyprland.packages.${system}.hyprland];
-        inputsFrom = [
-          hyprland.packages.${system}.hyprland
-          self.packages.${system}.Hyprspace
-        ];
-
-        shellHook = ''
-          meson setup build --reconfigure
-          sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
-        '';
-      };
-    });
-
-    formatter = perSystem (_: pkgs: pkgs.alejandra);
-  };
+      formatter = perSystem (_: pkgs: pkgs.alejandra);
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,3 @@
     formatter = perSystem (_: pkgs: pkgs.alejandra);
   };
 }
-
-      formatter = perSystem (_: pkgs: pkgs.alejandra);
-    };
-}

--- a/flake.nix
+++ b/flake.nix
@@ -3,88 +3,85 @@
 
   inputs.hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
 
-  outputs =
-    { self, hyprland, ... }:
-    let
-      inherit (builtins)
-        elemAt
-        head
-        readFile
-        split
-        substring
-        ;
-      inherit (hyprland.inputs) nixpkgs;
-      inherit (nixpkgs) lib;
+  outputs = {
+    self,
+    hyprland,
+    ...
+  }: let
+    inherit (builtins) elemAt head readFile split substring;
+    inherit (hyprland.inputs) nixpkgs;
+    inherit (nixpkgs) lib;
 
-      # System types to support.
-      supportedSystems = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
+    # System types to support.
+    supportedSystems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
 
-      perSystem = attrs: lib.genAttrs supportedSystems (system: attrs system nixpkgs.legacyPackages.${system});
+    perSystem = attrs:
+      lib.genAttrs supportedSystems (system:
+        attrs system nixpkgs.legacyPackages.${system});
 
-      # Generate version
-      mkDate =
-        longDate:
-        (lib.concatStringsSep "-" [
-          (substring 0 4 longDate)
-          (substring 4 2 longDate)
-          (substring 6 2 longDate)
-        ]);
+    # Generate version
+    mkDate = longDate: (lib.concatStringsSep "-" [
+      (substring 0 4 longDate)
+      (substring 4 2 longDate)
+      (substring 6 2 longDate)
+    ]);
 
-      version =
-        (head (split "'" (elemAt (split " version: '" (readFile ./meson.build)) 2)))
-        + "+date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
-    in
-    {
-      # Provide some binary packages for selected system types
-      packages = perSystem (
-        system: pkgs: {
-          Hyprspace =
-            let
-              hyprlandPkg = hyprland.packages.${system}.hyprland;
-            in
-            pkgs.gcc13Stdenv.mkDerivation {
-              pname = "Hyprspace";
-              inherit version;
-              src = ./.;
+    version =
+      (head (split "'"
+        (elemAt
+          (split " version: '" (readFile ./meson.build))
+          2)))
+      + "+date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
+  in {
+    # Provide some binary packages for selected system types
+    packages = perSystem (system: pkgs: {
+      Hyprspace = let
+        hyprlandPkg = hyprland.packages.${system}.hyprland;
+      in
+        pkgs.gcc13Stdenv.mkDerivation {
+          pname = "Hyprspace";
+          inherit version;
+          src = ./.;
 
-              nativeBuildInputs = hyprlandPkg.nativeBuildInputs ++ [ pkgs.meson ];
-              buildInputs = [ hyprlandPkg ] ++ hyprlandPkg.buildInputs;
-              dontUseCmakeConfigure = true;
+          nativeBuildInputs = hyprlandPkg.nativeBuildInputs ++ [ pkgs.meson ];
+          buildInputs = [hyprlandPkg] ++ hyprlandPkg.buildInputs;
+          dontUseCmakeConfigure = true;
 
-              meta = with lib; {
-                homepage = "https://github.com/KZDKM/Hyprspace";
-                description = "Workspace overview plugin for Hyprland";
-                license = licenses.gpl2Only;
-                platforms = platforms.linux;
-              };
-            };
-          default = self.packages.${system}.Hyprspace;
-        }
-      );
-
-      # The default environment for 'nix develop'
-      devShells = perSystem (
-        system: pkgs: {
-          default = pkgs.mkShell {
-            name = "Hyprspace-shell";
-
-            nativeBuildInputs = with pkgs; [ gcc13 ];
-            buildInputs = [ hyprland.packages.${system}.hyprland ];
-            inputsFrom = [
-              hyprland.packages.${system}.hyprland
-              self.packages.${system}.Hyprspace
-            ];
-
-            shellHook = ''
-              meson setup build --reconfigure
-              sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
-            '';
+          meta = with lib; {
+            homepage = "https://github.com/KZDKM/Hyprspace";
+            description = "Workspace overview plugin for Hyprland";
+            license = licenses.gpl2Only;
+            platforms = platforms.linux;
           };
-        }
-      );
+        };
+      default = self.packages.${system}.Hyprspace;
+    });
+
+    # The default environment for 'nix develop'
+    devShells = perSystem (system: pkgs: {
+      default = pkgs.mkShell {
+        name = "Hyprspace-shell";
+
+        nativeBuildInputs = with pkgs; [gcc13];
+        buildInputs = [hyprland.packages.${system}.hyprland];
+        inputsFrom = [
+          hyprland.packages.${system}.hyprland
+          self.packages.${system}.Hyprspace
+        ];
+
+        shellHook = ''
+          meson setup build --reconfigure
+          sed -e 's/c++23/c++2b/g' ./build/compile_commands.json > ./compile_commands.json
+        '';
+      };
+    });
+
+    formatter = perSystem (_: pkgs: pkgs.alejandra);
+  };
+}
 
       formatter = perSystem (_: pkgs: pkgs.alejandra);
     };


### PR DESCRIPTION
Appended meson to nativeBuildInputs as hyprlandPkg.nativeBuildInputs no longer includes the meson package. hyprwm/Hyprland@752604cfe954bd96bd6b5aca3e80dafb6a426cfb

Should fix #79 