### PR TITLE
Complete the replacement of CColor with CHyprColor

### DIFF
--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -244,10 +244,10 @@ void CHyprspaceWidget::draw() {
             CBox miniPanelBox = {curWorkspaceRectOffsetX, curWorkspaceRectOffsetY, widgetBox.w * monitorSizeScaleFactor, widgetBox.h * monitorSizeScaleFactor};
             if (Config::onBottom) miniPanelBox = {curWorkspaceRectOffsetX, curWorkspaceRectOffsetY + workspaceBoxH - widgetBox.h * monitorSizeScaleFactor, widgetBox.w * monitorSizeScaleFactor, widgetBox.h * monitorSizeScaleFactor};
             if (!Config::disableBlur) {
-                g_pHyprOpenGL->renderRectWithBlur(&miniPanelBox, CColor(0, 0, 0, 0), 0, 1.f, false);
+                g_pHyprOpenGL->renderRectWithBlur(&miniPanelBox, CHyprColor(0, 0, 0, 0), 0, 1.f, false);
             }
             else {
-                g_pHyprOpenGL->renderRect(&miniPanelBox, CColor(0, 0, 0, 0), 0);
+                g_pHyprOpenGL->renderRect(&miniPanelBox, CHyprColor(0, 0, 0, 0), 0);
             }
         }
 


### PR DESCRIPTION
When the merge conflict between #117 and #118 was resolved, two instances of CColor from #117 was inadvertently left in. This replaces the last remaining instances of CColor with CHyprColor, which fixes the building of Hyprspace for upstream Hyprland.