### PR TITLE
fix: lsp not reading compile_commands.json

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
     devShells = perSystem (system: pkgs: {
       default = pkgs.mkShell {
         name = "Hyprspace-shell";
-        nativeBuildInputs = with pkgs; [gcc14];
+        nativeBuildInputs = with pkgs; [gcc14 clang-tools bear];
         buildInputs = [hyprland.packages.${system}.hyprland];
         inputsFrom = [
           hyprland.packages.${system}.hyprland


### PR DESCRIPTION
When entering `nix develop` lsp cannot read compile_commands.json (idk why)