### PR TITLE
feat(overview): add configurable exit key for overview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Refer to the [Hyprland wiki](https://wiki.hyprland.org/Nix/Hyprland-on-Home-Mana
 - `plugin:overview:showSpecialWorkspace` defaults to false
 - `plugin:overview:disableGestures`
 - `plugin:overview:reverseSwipe` reverses the direction of swipe gesture, for macOS peeps?
+- `plugin:overview:exitKey` key code used to exit overview mode (default: KEY_ESC/1). Set to 0 to disable keyboard exit.
 - Touchpad gesture behavior follows Hyprland workspace swipe behavior
   - `gestures:workspace_swipe_fingers`
   - `gestures:workspace_swipe_cancel_ratio`


### PR DESCRIPTION

- Introduced `plugin:overview:exitKey` for customizable exit key (default: KEY_ESC).
- Disabled keyboard exit when `exitKey` is set to 0.
- Updated key handling logic in `onKeyPress`.
- Registered `exitKey` in plugin initialization.

Solved a issue using esc bind in hyprland.conf while overview is active, the bind is not triggered since hyprspace was trapping the event.