### PR TITLE
feat: use keysym instead of keycode for exitKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Refer to the [Hyprland wiki](https://wiki.hyprland.org/Nix/Hyprland-on-Home-Mana
 - `plugin:overview:showSpecialWorkspace` defaults to false
 - `plugin:overview:disableGestures`
 - `plugin:overview:reverseSwipe` reverses the direction of swipe gesture, for macOS peeps?
-- `plugin:overview:exitKey` key code used to exit overview mode (default: KEY_ESC/1). Set to 0 to disable keyboard exit.
+- `plugin:overview:exitKey` key used to exit overview mode (default: Escape). Leave empty to disable keyboard exit.
 - Touchpad gesture behavior follows Hyprland workspace swipe behavior
   - `gestures:workspace_swipe_fingers`
   - `gestures:workspace_swipe_cancel_ratio`

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,16 +255,20 @@ void onSwipeEnd(void* thisptr, SCallbackInfo& info, std::any args) {
 // Close overview with configurable key
 void onKeyPress(void* thisptr, SCallbackInfo& info, std::any args) {
     const auto e = std::any_cast<IKeyboard::SKeyEvent>(std::any_cast<std::unordered_map<std::string, std::any>>(args)["event"]);
-    //const auto k = std::any_cast<SKeyboard*>(std::any_cast<std::unordered_map<std::string, std::any>>(args)["keyboard"]);
+    const auto k = std::any_cast<SP<IKeyboard>>(std::any_cast<std::unordered_map<std::string, std::any>>(args)["keyboard"]);
 
-    // Get configured exit key (default to ESC if not configured)
-    const auto exitKey = std::any_cast<Hyprlang::INT>(HyprlandAPI::getConfigValue(pHandle, "plugin:overview:exitKey")->getValue());
-    
-    // If exit key is 0, disable keyboard exit
-    if (exitKey == 0)
+    const auto keycode = e.keycode + 8; // Because to xkbcommon it's +8 from libinput
+    const xkb_keysym_t keysym = xkb_state_key_get_one_sym(k->xkbSymState, keycode);
+
+    // Get configured exit key (default to Escape if not configured)
+    const auto cfgExitKey = std::any_cast<Hyprlang::STRING>(HyprlandAPI::getConfigValue(pHandle, "plugin:overview:exitKey")->getValue());
+    const xkb_keysym_t cfgExitKeysym = xkb_keysym_from_name(cfgExitKey, XKB_KEYSYM_CASE_INSENSITIVE);
+
+    // If exit key is empty, disable keyboard exit
+    if (cfgExitKey[0] == '\0')
         return;
-        
-    if (e.keycode == exitKey) {
+
+    if (keysym == cfgExitKeysym) {
         // close all panels
         bool overviewActive = false;
         for (auto& widget : g_overviewWidgets) {
@@ -501,7 +505,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:disableBlur", Hyprlang::INT{0});
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:overrideAnimSpeed", Hyprlang::FLOAT{0.0});
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:dragAlpha", Hyprlang::FLOAT{0.2});
-    HyprlandAPI::addConfigValue(pHandle, "plugin:overview:exitKey", Hyprlang::INT{KEY_ESC});
+    HyprlandAPI::addConfigValue(pHandle, "plugin:overview:exitKey", Hyprlang::STRING{"Escape"});
 
     g_pConfigReloadHook = HyprlandAPI::registerCallbackDynamic(pHandle, "configReloaded", [&] (void* thisptr, SCallbackInfo& info, std::any data) { reloadConfig(); });
     HyprlandAPI::reloadConfig();


### PR DESCRIPTION
Currently, exitKey is checking for the pressed key's keycode. I think it should be checking for the keysym.

In my hyprland's configuration, I have set my `caps lock` key to be the same as `escape` using the xkb-option `caps:escape`. With the current implementation of keycode, I can close the overview by pressing `esc` but not when I press `caps lock`. By checking for keysym instead of keycode, it works with both keys now, as expected.

Please review the changes carefully, as this is my first time writing C++ and also my first time writing code for a hyprland plugin. I read the relevant sections in hyprland's source code and kind of guessed the changes based on that and through trial and error.