### PR TITLE
Add explicit support for split-monitor-workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://github.com/KZDKM/Hyprspace/assets/41317840/ed1a585a-30d5-4a79-a6da-8cc07
 
 ## Plugin Compatibility
 - [x] [hyprsplit](https://github.com/shezdy/hyprsplit) (tested, explicit support)
+- [x] [split-monitor-workspaces](https://github.com/Duckonaut/split-monitor-workspaces) (tested, explicit support)
 - [x] [hyprexpo](https://github.com/hyprwm/hyprland-plugins/tree/main/hyprexpo) (tested, minor bugs)
 - [x] Any layout plugin (except ones that override Hyprland's workspace management)
 
@@ -37,7 +38,7 @@ https://github.com/KZDKM/Hyprspace/assets/41317840/ed1a585a-30d5-4a79-a6da-8cc07
     - [x] Autodrag windows
     - [x] Autoscroll workspaces
     - [x] Responsive workspace switching
-    - [x] Responsive exiting 
+    - [x] Responsive exiting
       - [x] Exit on click / switch
       - [x] Exit with escape key
     - [x] Blacklisting workspaces
@@ -166,5 +167,3 @@ Refer to the [Hyprland wiki](https://wiki.hyprland.org/Nix/Hyprland-on-Home-Mana
   - `gestures:workspace_swipe_fingers`
   - `gestures:workspace_swipe_cancel_ratio`
   - `gestures:workspace_swipe_min_speed_to_force`
-
-

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -62,4 +62,4 @@ namespace Config {
     extern float dragAlpha;
 }
 
-extern int hyprsplitNumWorkspaces;
+extern int numWorkspaces;

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -231,10 +231,10 @@ void CHyprspaceWidget::draw() {
         int wsIDStart = 1;
         int wsIDEnd = highestID;
 
-        // hyprsplit compatibility
-        if (hyprsplitNumWorkspaces > 0) {
-            wsIDStart = std::min<int>(hyprsplitNumWorkspaces * ownerID + 1, lowestID);
-            wsIDEnd = std::max<int>(hyprsplitNumWorkspaces * ownerID + 1, highestID); // always show the initial workspace for current monitor
+        // hyprsplit/split-monitor-workspaces compatibility
+        if (numWorkspaces > 0) {
+            wsIDStart = std::min<int>(numWorkspaces * ownerID + 1, lowestID);
+            wsIDEnd = std::max<int>(numWorkspaces * ownerID + 1, highestID); // always show the initial workspace for current monitor
         }
 
         for (int i = wsIDStart; i <= wsIDEnd; i++) {
@@ -313,7 +313,7 @@ void CHyprspaceWidget::draw() {
                 renderLayerStub(ls.lock(), owner, layerBox, &time);
                 g_pHyprOpenGL->m_renderData.clipBox = CBox();
             }
-        } 
+        }
 
         // the mini panel to cover the awkward empty space reserved by the panel
         if (owner->m_activeWorkspace == ws && Config::affectStrut) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@ float Config::overrideAnimSpeed = 0;
 
 float Config::dragAlpha = 0.2;
 
-int hyprsplitNumWorkspaces = -1;
+int numWorkspaces = -1; //hyprsplit/split-monitor-workspaces support
 
 Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pRenderHook;
 Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pConfigReloadHook;
@@ -442,10 +442,12 @@ void reloadConfig() {
 
     Config::dragAlpha = std::any_cast<Hyprlang::FLOAT>(HyprlandAPI::getConfigValue(pHandle, "plugin:overview:dragAlpha")->getValue());
 
+    // get number of workspaces from hyprsplit or split-monitor-workspaces plugin config
     Hyprlang::CConfigValue* numWorkspacesConfig = HyprlandAPI::getConfigValue(pHandle, "plugin:hyprsplit:num_workspaces");
-
+    if (!numWorkspacesConfig)
+        numWorkspacesConfig = HyprlandAPI::getConfigValue(pHandle, "plugin:split-monitor-workspaces:count");
     if (numWorkspacesConfig)
-        hyprsplitNumWorkspaces = std::any_cast<Hyprlang::INT>(numWorkspacesConfig->getValue());
+        numWorkspaces = std::any_cast<Hyprlang::INT>(numWorkspacesConfig->getValue());
 
     // TODO: schedule frame for monitor?
 }


### PR DESCRIPTION
Tested with the following config:

```
plugin {
    split-monitor-workspaces {
        count = 5
        keep_focused = 1
        enable_notifications = 0
        enable_persistent_workspaces = 1
    }

    overview {
        # colors
        workspaceActiveBorder = rgba(5e81acff)
        workspaceInactiveBorder = rgba(00000000)
        dragAlpha = 0.7
        disableBlur = true

        # layout
        overrideGaps = false
        centerAligned = true

        # behavior
        showNewWorkspace = false
    }
}
```
Changing the `count` properly reloads the Hyprland config and also updates the number of workspaces shown by Hyprspace.

---

By default `split-monitor-workspaces` creates $count persistent workspaces, which Hyprspace picks up automatically so if you don't explicitly set `enable_persistent_workspaces` to `0`, this PR isn't actually necessary.

The explicit support added in this PR fixes a bug where if you disable persistent workspaces, Hyprspace would show the wrong workspaces on the wrong monitor. 

For example: I have 2 monitors with each 5 workspaces. Monitor 1 has workspaces 1-5, monitor 2 has workspaces 6-10.
This is how my waybar looks if I disabled persistent workspaces, and workspaces 6 and 7 on monitor 2 are not empty:

![image](https://github.com/user-attachments/assets/fc9b0bac-593b-4158-93e2-7c7ad15f8e35)

Before this PR, Hyprspace would show workspace 2-7 when $count is 5:

![image](https://github.com/user-attachments/assets/4bd4cae7-6602-42d0-9ee8-9b1a616084a5)

(workspace 1 is in use by monitor 1, and workspaces 2-5 are empty)

After this PR, it correctly shows only workspaces 6 and 7:

![image](https://github.com/user-attachments/assets/52bd8208-48cc-46e1-a5b3-2e643380f28b)
