### PR TITLE
Fix for Hyprland 0.50.1: use addDispatcherV2, m_workspaces, m_activeW…

### DIFF
--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -25,9 +25,9 @@ void CHyprspaceWidget::updateLayout() {
     if (active) {
         const auto oActiveWorkspace = pMonitor->m_activeWorkspace;
 
-        for (auto& ws : g_pCompositor->getWorkspaces()) { // HACK: recalculate other workspaces without reserved area
+        for (auto& ws : g_pCompositor->m_workspaces) { // HACK: recalculate other workspaces without reserved area
             if (ws->m_monitor->m_id == ownerID && ws->m_id != oActiveWorkspace->m_id) {
-                pMonitor->m_activeWorkspace = ws.lock();
+                pMonitor->m_activeWorkspace = ws;
                 const auto curRules = std::to_string(pMonitor->activeWorkspaceID()) + ", gapsin:" + PGAPSIN->toString() + ", gapsout:" + PGAPSOUT->toString();
                 if (Config::overrideGaps) g_pConfigManager->handleWorkspaceRules("", curRules);
                 g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ownerID);
@@ -44,7 +44,7 @@ void CHyprspaceWidget::updateLayout() {
 
     }
     else {
-        for (auto& ws : g_pCompositor->getWorkspaces()) {
+        for (auto& ws : g_pCompositor->m_workspaces) {
             if (ws->m_monitor->m_id == ownerID) {
                 const auto curRules = std::to_string(ws->m_id) + ", gapsin:" + PGAPSIN->toString() + ", gapsout:" + PGAPSOUT->toString();
                 if (Config::overrideGaps) g_pConfigManager->handleWorkspaceRules("", curRules);

--- a/src/Overview.cpp
+++ b/src/Overview.cpp
@@ -32,7 +32,7 @@ void CHyprspaceWidget::show() {
 
     if (prevFullscreen.empty()) {
         // unfullscreen all windows
-        for (auto& ws : g_pCompositor->getWorkspaces()) {
+        for (auto& ws : g_pCompositor->m_workspaces) {
             if (ws->m_monitor->m_id == ownerID) {
                 const auto w = ws->getFullscreenWindow();
                 if (w != nullptr && ws->m_fullscreenMode != FSMODE_NONE) {

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -77,7 +77,7 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     const auto oPinned = pWindow->m_pinned;
     const auto oDraggedWindow = g_pInputManager->m_currentlyDraggedWindow;
     const auto oDragMode = g_pInputManager->m_dragMode;
-    const auto oRenderModifEnable = g_pHyprOpenGL->m_renderData.renderModif.enabled;
+    //const auto oRenderModifEnable = g_pHyprOpenGL->m_renderData.renderModif.enabled;
     const auto oFloating = pWindow->m_isFloating;
 
     const float curScaling = rectOverride.w / (oSize.x * pMonitor->m_scale);
@@ -125,7 +125,7 @@ void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, times
     Vector2D oRealPosition = pLayer->m_realPosition->value();
     Vector2D oSize = pLayer->m_realSize->value();
     float oAlpha = pLayer->m_alpha->value(); // set to 1 to show hidden top layer
-    const auto oRenderModifEnable = g_pHyprOpenGL->m_renderData.renderModif.enabled;
+    //const auto oRenderModifEnable = g_pHyprOpenGL->m_renderData.renderModif.enabled;
     const auto oFadingOut = pLayer->m_fadingOut;
 
     const float curScaling = rectOverride.w / (oSize.x);
@@ -188,7 +188,7 @@ void CHyprspaceWidget::draw() {
     // Panel Border
     if (Config::panelBorderWidth > 0) {
         // Border box
-        CBox borderBox = {widgetBox.x, owner->m_position.y + (Config::onBottom * owner->m_transformedSize.y) + (Config::panelHeight + Config::reservedArea - curYOffset->value() * owner->m_scale) * bottomInvert, owner->m_transformedSize.x, Config::panelBorderWidth};
+        CBox borderBox = {widgetBox.x, owner->m_position.y + (Config::onBottom * owner->m_transformedSize.y) + (Config::panelHeight + Config::reservedArea - curYOffset->value() * owner->m_scale) * bottomInvert, owner->m_transformedSize.x, static_cast<double>(Config::panelBorderWidth)};
         borderBox.y -= owner->m_position.y;
 
         renderRect(borderBox, Config::panelBorderColor);
@@ -216,7 +216,7 @@ void CHyprspaceWidget::draw() {
     // find the lowest and highest workspace id to determine which empty workspaces to insert
     int lowestID = INT_MAX;
     int highestID = 1;
-    for (auto& ws : g_pCompositor->getWorkspaces()) {
+    for (auto& ws : g_pCompositor->m_workspaces) {
         if (!ws) continue;
         // normal workspaces start from 1, special workspaces ends on -2
         if (ws->m_id < 1) continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -512,9 +512,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     g_pConfigReloadHook = HyprlandAPI::registerCallbackDynamic(pHandle, "configReloaded", [&] (void* thisptr, SCallbackInfo& info, std::any data) { reloadConfig(); });
     HyprlandAPI::reloadConfig();
 
-    HyprlandAPI::addDispatcher(pHandle, "overview:toggle", ::dispatchToggleOverview);
-    HyprlandAPI::addDispatcher(pHandle, "overview:open", ::dispatchOpenOverview);
-    HyprlandAPI::addDispatcher(pHandle, "overview:close", ::dispatchCloseOverview);
+    HyprlandAPI::addDispatcherV2(pHandle, "overview:toggle", ::dispatchToggleOverview);
+    HyprlandAPI::addDispatcherV2(pHandle, "overview:open", ::dispatchOpenOverview);
+    HyprlandAPI::addDispatcherV2(pHandle, "overview:close", ::dispatchCloseOverview);
 
     g_pRenderHook = HyprlandAPI::registerCallbackDynamic(pHandle, "render", onRender);
 


### PR DESCRIPTION
Fixes compatibility with Hyprland 0.50.1:
- Replace `addDispatcher` with `addDispatcherV2` in `main.cpp`.
- Update `m_workspaces` and `m_activeWorkspace` in `Overview.cpp`, `Layout.cpp`.
- Remove unused `oRenderModifEnable` and add `static_cast<double>` in `Render.cpp` to clear warnings.