### PR TITLE
Update AnimationManager headers import

### DIFF
--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -6,7 +6,7 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/managers/LayoutManager.hpp>
-#include <hyprland/src/managers/AnimationManager.hpp>
+#include <hyprland/src/managers/animation/AnimationManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 
 inline HANDLE pHandle = NULL;


### PR DESCRIPTION
Hello,

The recent Hyprland update (0.51) seems to have moved the AnimationManager header to a new subfolder `animation` [here](https://github.com/hyprwm/Hyprland/commit/81bf4eccba449bfe2b6adfb51260108aec710d4f#diff-a9a6b1d55697fefe790ae4fd3a7dc0099fc396fe303e0a30d479fea37888e88a). As Hyprspace seems to still reference the old location `make all` fails with e.g.:

```In file included from src/Input.cpp:2:
src/Globals.hpp:9:10: fatal error: hyprland/src/managers/AnimationManager.hpp: No such file or directory
    9 | #include <hyprland/src/managers/AnimationManager.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

This small PR fixes compilation by updating the import accordingly :)