### PR TITLE
Supersede #223: Hyprland 0.54.x compatibility + runtime fixes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       owner = "hyprwm";
       repo = "Hyprland";
       type = "github";
+      ref = "v0.54.2";
       inputs.systems.follows = "systems";
     };
   };

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -5,7 +5,9 @@
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
-#include <hyprland/src/managers/LayoutManager.hpp>
+#include <hyprland/src/layout/LayoutManager.hpp>
+#include <hyprland/src/event/EventBus.hpp>
+#include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/managers/animation/AnimationManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 
@@ -14,9 +16,9 @@ inline HANDLE pHandle = NULL;
 typedef SDispatchResult (*tMouseKeybind)(std::string);
 extern void* pMouseKeybind;
 
-typedef void (*tRenderWindow)(void*, PHLWINDOW, PHLMONITOR, timespec*, bool, eRenderPassMode, bool, bool);
+typedef void (*tRenderWindow)(void*, PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool, bool);
 extern void* pRenderWindow;
-typedef void (*tRenderLayer)(void*, PHLLSREF, PHLMONITOR, timespec*, bool);
+typedef void (*tRenderLayer)(void*, PHLLS, PHLMONITOR, const Time::steady_tp&, bool, bool);
 extern void* pRenderLayer;
 namespace Config {
     extern CHyprColor panelBaseColor;

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -11,21 +11,7 @@
 #include <hyprland/src/managers/animation/AnimationManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
 #include <hyprutils/signal/Signal.hpp>
-#include <functional>
 #include <tuple>
-
-// Helper to register a cancellable event listener that properly unpacks
-// std::tuple<const EventType&, SCallbackInfo&> from the signal's void* args.
-template <typename EventType, typename Signal>
-CHyprSignalListener listenCancellable(Signal& signal, std::function<void(const EventType&, Event::SCallbackInfo&)> handler) {
-    struct Hack : Hyprutils::Signal::CSignalBase {
-        using CSignalBase::registerListenerInternal;
-    };
-    return reinterpret_cast<Hack&>(signal).registerListenerInternal([handler](void* args) {
-        auto* tup = static_cast<std::tuple<const EventType&, Event::SCallbackInfo&>*>(args);
-        handler(std::get<0>(*tup), std::get<1>(*tup));
-    });
-}
 
 inline HANDLE pHandle = NULL;
 
@@ -36,6 +22,7 @@ typedef void (*tRenderWindow)(void*, PHLWINDOW, PHLMONITOR, const Time::steady_t
 extern void* pRenderWindow;
 typedef void (*tRenderLayer)(void*, PHLLS, PHLMONITOR, const Time::steady_tp&, bool, bool);
 extern void* pRenderLayer;
+extern bool g_renderHooksReady;
 namespace Config {
     extern CHyprColor panelBaseColor;
     extern CHyprColor panelBorderColor;

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -6,7 +6,6 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/layout/LayoutManager.hpp>
-#include <hyprland/src/layout/target/WindowTarget.hpp>
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/managers/animation/AnimationManager.hpp>

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -6,6 +6,7 @@
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/layout/LayoutManager.hpp>
+#include <hyprland/src/layout/target/WindowTarget.hpp>
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/managers/animation/AnimationManager.hpp>

--- a/src/Globals.hpp
+++ b/src/Globals.hpp
@@ -10,6 +10,22 @@
 #include <hyprland/src/helpers/time/Time.hpp>
 #include <hyprland/src/managers/animation/AnimationManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
+#include <hyprutils/signal/Signal.hpp>
+#include <functional>
+#include <tuple>
+
+// Helper to register a cancellable event listener that properly unpacks
+// std::tuple<const EventType&, SCallbackInfo&> from the signal's void* args.
+template <typename EventType, typename Signal>
+CHyprSignalListener listenCancellable(Signal& signal, std::function<void(const EventType&, Event::SCallbackInfo&)> handler) {
+    struct Hack : Hyprutils::Signal::CSignalBase {
+        using CSignalBase::registerListenerInternal;
+    };
+    return reinterpret_cast<Hack&>(signal).registerListenerInternal([handler](void* args) {
+        auto* tup = static_cast<std::tuple<const EventType&, Event::SCallbackInfo&>*>(args);
+        handler(std::get<0>(*tup), std::get<1>(*tup));
+    });
+}
 
 inline HANDLE pHandle = NULL;
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -35,14 +35,19 @@ bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
         targetWorkspace = g_pCompositor->createNewWorkspace(targetWorkspaceID, getOwner()->m_id);
     }
 
-    // if the cursor is hovering over workspace, clicking should switch workspace instead of starting window drag
-    if (Config::autoDrag && (targetWorkspace == nullptr || !pressed)) {
-        // when overview is active, always drag windows on mouse click
-        if (g_layoutManager->dragController()->target()) {
-            g_layoutManager->endDragTarget();
+    if (pressed) {
+        // on press: check if cursor is over a window thumbnail and begin drag
+        for (auto& [wref, wbox] : windowBoxes) {
+            if (wbox.containsPoint(coords)) {
+                if (auto w = wref.lock())
+                    g_layoutManager->beginDragTarget(Layout::CWindowTarget::create(w), MBIND_MOVE);
+                return false;
+            }
         }
-        std::string keybind = (pressed ? "1" : "0") + std::string("movewindow");
-        (*(tMouseKeybind)pMouseKeybind)(keybind);
+    } else {
+        // on release: end any active drag
+        if (g_layoutManager->dragController()->target())
+            g_layoutManager->endDragTarget();
     }
     Return = false;
 

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -2,11 +2,6 @@
 #include "Globals.hpp"
 
 bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
-    bool Return;
-
-    PHLWINDOW targetWindow;
-    if (const auto dragTarget = g_layoutManager->dragController()->target())
-        targetWindow = dragTarget->window();
 
     // this is for click to exit, we set a timeout for button release
     bool couldExit = false;
@@ -39,34 +34,31 @@ bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
         // on press: check if cursor is over a window thumbnail and begin drag
         for (auto& [wref, wbox] : windowBoxes) {
             if (wbox.containsPoint(coords)) {
-                if (auto w = wref.lock())
-                    g_layoutManager->beginDragTarget(Layout::CWindowTarget::create(w), MBIND_MOVE);
+                draggedWindowRef = wref;
                 return false;
             }
         }
-    } else {
-        // on release: end any active drag
-        if (g_layoutManager->dragController()->target())
-            g_layoutManager->endDragTarget();
+    } else if (auto dw = draggedWindowRef.lock()) {
+        // on release: drop dragged window into target workspace
+        draggedWindowRef.reset();
+        if (targetWorkspace != nullptr) {
+            g_pCompositor->moveWindowToWorkspaceSafe(dw, targetWorkspace);
+            if (dw->m_isFloating) {
+                auto targetPos = getOwner()->m_position + (getOwner()->m_size / 2.) - (dw->m_reportedSize / 2.);
+                dw->m_position = targetPos;
+                *dw->m_realPosition = targetPos;
+            }
+            if (Config::switchOnDrop) {
+                g_pCompositor->getMonitorFromID(targetWorkspace->m_monitor->m_id)->changeWorkspace(targetWorkspace->m_id);
+                if (Config::exitOnSwitch && active) hide();
+            }
+            updateLayout();
+        }
+        return false;
     }
-    Return = false;
 
-    // release window on workspace to drop it in
-    if (targetWindow && targetWorkspace != nullptr && !pressed) {
-        g_pCompositor->moveWindowToWorkspaceSafe(targetWindow, targetWorkspace);
-        if (targetWindow->m_isFloating) {
-            auto targetPos = getOwner()->m_position + (getOwner()->m_size / 2.) - (targetWindow->m_reportedSize / 2.);
-            targetWindow->m_position = targetPos;
-            *targetWindow->m_realPosition = targetPos;
-        }
-        if (Config::switchOnDrop) {
-            g_pCompositor->getMonitorFromID(targetWorkspace->m_monitor->m_id)->changeWorkspace(targetWorkspace->m_id);
-            if (Config::exitOnSwitch && active) hide();
-        }
-        updateLayout();
-    }
     // click workspace to change to workspace and exit overview
-    else if (targetWorkspace && !pressed) {
+    if (targetWorkspace && !pressed) {
         if (targetWorkspace->m_isSpecialWorkspace)
             getOwner()->activeSpecialWorkspaceID() == targetWorkspaceID ? getOwner()->setSpecialWorkspace(nullptr) : getOwner()->setSpecialWorkspace(targetWorkspaceID);
         else {
@@ -77,7 +69,7 @@ bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
     // click elsewhere to exit overview
     else if (Config::exitOnClick && targetWorkspace == nullptr && active && couldExit && !pressed) hide();
 
-    return Return;
+    return false;
 }
 
 bool CHyprspaceWidget::axisEvent(double delta, wl_pointer_axis axis, Vector2D coords) {

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -4,7 +4,9 @@
 bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
     bool Return;
 
-    const auto targetWindow = g_pInputManager->m_currentlyDraggedWindow.lock();
+    PHLWINDOW targetWindow;
+    if (const auto dragTarget = g_layoutManager->dragController()->target())
+        targetWindow = dragTarget->window();
 
     // this is for click to exit, we set a timeout for button release
     bool couldExit = false;
@@ -36,10 +38,8 @@ bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
     // if the cursor is hovering over workspace, clicking should switch workspace instead of starting window drag
     if (Config::autoDrag && (targetWorkspace == nullptr || !pressed)) {
         // when overview is active, always drag windows on mouse click
-        if (const auto curWindow = g_pInputManager->m_currentlyDraggedWindow.lock()) {
-            g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
-            g_pInputManager->m_currentlyDraggedWindow.reset();
-            g_pInputManager->m_dragMode = MBIND_INVALID;
+        if (g_layoutManager->dragController()->target()) {
+            g_layoutManager->endDragTarget();
         }
         std::string keybind = (pressed ? "1" : "0") + std::string("movewindow");
         (*(tMouseKeybind)pMouseKeybind)(keybind);

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -75,17 +75,23 @@ bool CHyprspaceWidget::buttonEvent(bool pressed, Vector2D coords) {
     return Return;
 }
 
-bool CHyprspaceWidget::axisEvent(double delta, Vector2D coords) {
+bool CHyprspaceWidget::axisEvent(double delta, wl_pointer_axis axis, Vector2D coords) {
 
     const auto owner = getOwner();
     CBox widgetBox = {owner->m_position.x, owner->m_position.y - curYOffset->value(), owner->m_transformedSize.x, (Config::panelHeight + Config::reservedArea) * owner->m_scale};
     if (Config::onBottom) widgetBox = {owner->m_position.x, owner->m_position.y + owner->m_transformedSize.y - ((Config::panelHeight + Config::reservedArea) * owner->m_scale) + curYOffset->value(), owner->m_transformedSize.x, (Config::panelHeight + Config::reservedArea) * owner->m_scale};
 
-    // scroll through panel if cursor is on it
+    // horizontal scroll pans the panel
+    if (axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
+        *workspaceScrollOffset = workspaceScrollOffset->goal() - delta * 2;
+        return false;
+    }
+
+    // scroll through panel if cursor is on it (vertical scroll)
     if (widgetBox.containsPoint(coords * getOwner()->m_scale)) {
         *workspaceScrollOffset = workspaceScrollOffset->goal() - delta * 2;
     }
-    // otherwise, scroll to switch active workspace
+    // otherwise, vertical scroll switches active workspace
     else {
         if (delta < 0) {
             SWorkspaceIDName wsIDName = getWorkspaceIDNameFromString("r-1");
@@ -105,7 +111,6 @@ bool CHyprspaceWidget::axisEvent(double delta, Vector2D coords) {
         }
     }
 
-
     return false;
 }
 
@@ -122,7 +127,7 @@ bool CHyprspaceWidget::beginSwipe(IPointer::SSwipeBeginEvent e) {
 }
 
 bool CHyprspaceWidget::updateSwipe(IPointer::SSwipeUpdateEvent e) {
-    int fingers = std::any_cast<Hyprlang::INT>(HyprlandAPI::getConfigValue(pHandle, "gestures:workspace_swipe_fingers")->getValue());
+    constexpr int fingers = 3;
     int distance = std::any_cast<Hyprlang::INT>(HyprlandAPI::getConfigValue(pHandle, "gestures:workspace_swipe_distance")->getValue());
 
     // restrict swipe to a axis with the most significant movement to prevent misinput

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -8,6 +8,7 @@ void CHyprspaceWidget::updateLayout() {
 
     const auto currentHeight = Config::panelHeight + Config::reservedArea;
     const auto pMonitor = getOwner();
+    if (!pMonitor) return;
 
     // reset reserved areas
     g_pHyprRenderer->arrangeLayersForMonitor(ownerID);

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -30,11 +30,11 @@ void CHyprspaceWidget::updateLayout() {
                 pMonitor->m_activeWorkspace = ws.lock();
                 const auto curRules = std::to_string(pMonitor->activeWorkspaceID()) + ", gapsin:" + PGAPSIN->toString() + ", gapsout:" + PGAPSOUT->toString();
                 if (Config::overrideGaps) g_pConfigManager->handleWorkspaceRules("", curRules);
-                g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ownerID);
+                g_layoutManager->recalculateMonitor(pMonitor);
             }
         }
         pMonitor->m_activeWorkspace = oActiveWorkspace;
-        
+
         if (!Config::onBottom) {
             pMonitor->m_reservedArea = Desktop::CReservedArea(
                 pMonitor->m_reservedArea.top() + currentHeight,
@@ -50,10 +50,10 @@ void CHyprspaceWidget::updateLayout() {
                 pMonitor->m_reservedArea.left()
             );
         }
-        
+
         const auto curRules = std::to_string(pMonitor->activeWorkspaceID()) + ", gapsin:" + std::to_string(Config::gapsIn) + ", gapsout:" + std::to_string(Config::gapsOut);
         if (Config::overrideGaps) g_pConfigManager->handleWorkspaceRules("", curRules);
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ownerID);
+        g_layoutManager->recalculateMonitor(pMonitor);
 
     }
     else {
@@ -61,7 +61,7 @@ void CHyprspaceWidget::updateLayout() {
             if (ws->m_monitor->m_id == ownerID) {
                 const auto curRules = std::to_string(ws->m_id) + ", gapsin:" + PGAPSIN->toString() + ", gapsout:" + PGAPSOUT->toString();
                 if (Config::overrideGaps) g_pConfigManager->handleWorkspaceRules("", curRules);
-                g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ownerID);
+                g_layoutManager->recalculateMonitor(pMonitor);
             }
         }
     }

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -10,13 +10,25 @@ void CHyprspaceWidget::updateLayout() {
     const auto pMonitor = getOwner();
     if (!pMonitor) return;
 
-    // reset reserved areas
-    g_pHyprRenderer->arrangeLayersForMonitor(ownerID);
-
     static auto PGAPSINDATA = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_in");
     static auto PGAPSOUTDATA = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_out");
     auto* const PGAPSIN = (CCssGapData*)(PGAPSINDATA.ptr())->getData();
     auto* const PGAPSOUT = (CCssGapData*)(PGAPSOUTDATA.ptr())->getData();
+
+    // Set panel reservation as initial values BEFORE arranging layers,
+    // so that arrangeLayersForMonitor adds LS reservations as dynamic data
+    // on top of our panel reservation without double-counting.
+    if (active) {
+        if (!Config::onBottom)
+            pMonitor->m_reservedArea = Desktop::CReservedArea(currentHeight, 0, 0, 0);
+        else
+            pMonitor->m_reservedArea = Desktop::CReservedArea(0, 0, currentHeight, 0);
+    } else {
+        pMonitor->m_reservedArea = Desktop::CReservedArea();
+    }
+
+    // arrange layers adds LS dynamic reservations on top of our initial values
+    g_pHyprRenderer->arrangeLayersForMonitor(ownerID);
 
     // gaps are created via workspace rules
     // there are no way to write to m_dWorkspaceRules directly
@@ -35,22 +47,6 @@ void CHyprspaceWidget::updateLayout() {
             }
         }
         pMonitor->m_activeWorkspace = oActiveWorkspace;
-
-        if (!Config::onBottom) {
-            pMonitor->m_reservedArea = Desktop::CReservedArea(
-                pMonitor->m_reservedArea.top() + currentHeight,
-                pMonitor->m_reservedArea.right(),
-                pMonitor->m_reservedArea.bottom(),
-                pMonitor->m_reservedArea.left()
-            );
-        } else {
-            pMonitor->m_reservedArea = Desktop::CReservedArea(
-                pMonitor->m_reservedArea.top(),
-                pMonitor->m_reservedArea.right(),
-                pMonitor->m_reservedArea.bottom() + currentHeight,
-                pMonitor->m_reservedArea.left()
-            );
-        }
 
         const auto curRules = std::to_string(pMonitor->activeWorkspaceID()) + ", gapsin:" + std::to_string(Config::gapsIn) + ", gapsout:" + std::to_string(Config::gapsOut);
         if (Config::overrideGaps) g_pConfigManager->handleWorkspaceRules("", curRules);

--- a/src/Overview.cpp
+++ b/src/Overview.cpp
@@ -14,6 +14,15 @@ CHyprspaceWidget::CHyprspaceWidget(uint64_t inOwnerID) {
         curAnimation.internalSpeed = Config::overrideAnimSpeed;
 
     g_pAnimationManager->createAnimation(0.F, curYOffset, curAnimationConfig.pValues.lock(), AVARDAMAGE_ENTIRE);
+    curYOffset->setCallbackOnEnd([this](auto) {
+        if (!active) {
+            auto owner = getOwner();
+            if (owner) {
+                g_pHyprRenderer->damageMonitor(owner);
+                g_pCompositor->scheduleFrameForMonitor(owner);
+            }
+        }
+    }, false);
     g_pAnimationManager->createAnimation(0.F, workspaceScrollOffset, curAnimationConfig.pValues.lock(), AVARDAMAGE_ENTIRE);
     curYOffset->setValueAndWarp(Config::panelHeight);
     workspaceScrollOffset->setValueAndWarp(0);
@@ -123,6 +132,7 @@ void CHyprspaceWidget::hide() {
     }
 
     updateLayout();
+    g_pHyprRenderer->damageMonitor(owner);
     g_pCompositor->scheduleFrameForMonitor(owner);
 }
 
@@ -137,6 +147,15 @@ void CHyprspaceWidget::updateConfig() {
         curAnimation.internalSpeed = Config::overrideAnimSpeed;
 
     g_pAnimationManager->createAnimation(0.F, curYOffset, curAnimationConfig.pValues.lock(), AVARDAMAGE_ENTIRE);
+    curYOffset->setCallbackOnEnd([this](auto) {
+        if (!active) {
+            auto owner = getOwner();
+            if (owner) {
+                g_pHyprRenderer->damageMonitor(owner);
+                g_pCompositor->scheduleFrameForMonitor(owner);
+            }
+        }
+    }, false);
     g_pAnimationManager->createAnimation(0.F, workspaceScrollOffset, curAnimationConfig.pValues.lock(), AVARDAMAGE_ENTIRE);
     curYOffset->setValueAndWarp(Config::panelHeight);
     workspaceScrollOffset->setValueAndWarp(0);

--- a/src/Overview.cpp
+++ b/src/Overview.cpp
@@ -19,6 +19,13 @@ CHyprspaceWidget::CHyprspaceWidget(uint64_t inOwnerID) {
             auto owner = getOwner();
             if (owner) {
                 g_pHyprRenderer->damageMonitor(owner);
+                for (auto& ws : g_pCompositor->getWorkspaces()) {
+                    if (!ws || ws->m_monitor->m_id != ownerID) continue;
+                    for (auto& w : g_pCompositor->m_windows) {
+                        if (!w || w->m_workspace != ws || !w->m_isMapped) continue;
+                        g_pHyprRenderer->damageWindow(w);
+                    }
+                }
                 g_pCompositor->scheduleFrameForMonitor(owner);
             }
         }
@@ -133,6 +140,13 @@ void CHyprspaceWidget::hide() {
 
     updateLayout();
     g_pHyprRenderer->damageMonitor(owner);
+    for (auto& ws : g_pCompositor->getWorkspaces()) {
+        if (!ws || ws->m_monitor->m_id != ownerID) continue;
+        for (auto& w : g_pCompositor->m_windows) {
+            if (!w || w->m_workspace != ws || !w->m_isMapped) continue;
+            g_pHyprRenderer->damageWindow(w);
+        }
+    }
     g_pCompositor->scheduleFrameForMonitor(owner);
 }
 
@@ -152,6 +166,13 @@ void CHyprspaceWidget::updateConfig() {
             auto owner = getOwner();
             if (owner) {
                 g_pHyprRenderer->damageMonitor(owner);
+                for (auto& ws : g_pCompositor->getWorkspaces()) {
+                    if (!ws || ws->m_monitor->m_id != ownerID) continue;
+                    for (auto& w : g_pCompositor->m_windows) {
+                        if (!w || w->m_workspace != ws || !w->m_isMapped) continue;
+                        g_pHyprRenderer->damageWindow(w);
+                    }
+                }
                 g_pCompositor->scheduleFrameForMonitor(owner);
             }
         }

--- a/src/Overview.cpp
+++ b/src/Overview.cpp
@@ -40,7 +40,7 @@ void CHyprspaceWidget::show() {
                     // fixes youtube fullscreen not restoring properly
                     if (ws->m_fullscreenMode == FSMODE_FULLSCREEN) w->m_wantsInitialFullscreen = true;
                     // we use the getWindowFromHandle function to prevent dangling pointers
-                    prevFullscreen.emplace_back(std::make_tuple((uint32_t)(((uint64_t)w.get()) & 0xFFFFFFFF), ws->m_fullscreenMode));
+                    prevFullscreen.emplace_back(std::make_tuple(PHLWINDOWREF(w), ws->m_fullscreenMode));
                     g_pCompositor->setWindowFullscreenState(w, Desktop::View::SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
                 }
             }
@@ -106,9 +106,10 @@ void CHyprspaceWidget::hide() {
 
     // restore fullscreen state
     for (auto& fs : prevFullscreen) {
-        const auto w = g_pCompositor->getWindowFromHandle(std::get<0>(fs));
+        const auto w = std::get<0>(fs).lock();
+        if (!w) continue;
         const auto oFullscreenMode = std::get<1>(fs);
-        g_pCompositor->setWindowFullscreenState(w, Desktop::View::SFullscreenState(oFullscreenMode)); 
+        g_pCompositor->setWindowFullscreenState(w, Desktop::View::SFullscreenState(oFullscreenMode));
         if (oFullscreenMode == FSMODE_FULLSCREEN) w->m_wantsInitialFullscreen = false;
     }
     prevFullscreen.clear();

--- a/src/Overview.hpp
+++ b/src/Overview.hpp
@@ -16,6 +16,13 @@ class CHyprspaceWidget {
     // modified on draw call, accessed on mouse click and release
     std::vector<std::tuple<int, CBox>> workspaceBoxes;
 
+    // for checking mouse hover over window thumbnails for drag initiation
+    // modified on draw call, accessed on mouse click
+    std::vector<std::tuple<PHLWINDOWREF, CBox>> windowBoxes;
+
+    // self-managed drag state: set on press over a window thumbnail, cleared on release
+    PHLWINDOWREF draggedWindowRef;
+
     // for storing the fullscreen state of windows prior to overview activation (which unfullscreens all windows)
     std::vector<std::tuple<PHLWINDOWREF, eFullscreenMode>> prevFullscreen;
 

--- a/src/Overview.hpp
+++ b/src/Overview.hpp
@@ -17,7 +17,7 @@ class CHyprspaceWidget {
     std::vector<std::tuple<int, CBox>> workspaceBoxes;
 
     // for storing the fullscreen state of windows prior to overview activation (which unfullscreens all windows)
-    std::vector<std::tuple<uint32_t, eFullscreenMode>> prevFullscreen;
+    std::vector<std::tuple<PHLWINDOWREF, eFullscreenMode>> prevFullscreen;
 
     // for storing the layer alpha values prior to overview activation (which sets all panel to transparent when configured)
     std::vector<std::tuple<PHLLS, float>> oLayerAlpha;
@@ -59,7 +59,7 @@ public:
     void updateLayout();
 
     bool buttonEvent(bool, Vector2D coords);
-    bool axisEvent(double, Vector2D coords);
+    bool axisEvent(double, wl_pointer_axis axis, Vector2D coords);
 
     bool isSwiping();
 

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -75,7 +75,6 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     pWindow->m_ruleApplicator->rounding().unset(Desktop::Types::PRIORITY_SET_PROP);
     pWindow->m_isFloating = oFloating;
     pWindow->m_pinned = oPinned;
-    pWindow->m_ruleApplicator->rounding().unset(Desktop::Types::PRIORITY_SET_PROP);
 }
 
 void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, const Time::steady_tp& time) {

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -1,42 +1,10 @@
 #include "Overview.hpp"
 #include "Globals.hpp"
-#include "src/helpers/memory/Memory.hpp"
 #include <hyprland/src/render/pass/RectPassElement.hpp>
 #include <hyprland/src/render/pass/BorderPassElement.hpp>
 #include <hyprland/src/render/pass/RendererHintsPassElement.hpp>
 #include <hyprlang.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
-
-// What are we even doing...
-class CFakeDamageElement : public IPassElement {
-public:
-    CBox       box;
-
-    CFakeDamageElement(const CBox& box) {
-        this->box = box;
-    }
-    virtual ~CFakeDamageElement() = default;
-
-    virtual void                draw(const CRegion& damage) {
-        return;
-    }
-    virtual bool                needsLiveBlur() {
-        return true; // hack
-    }
-    virtual bool                needsPrecomputeBlur() {
-        return false;
-    }
-    virtual std::optional<CBox> boundingBox() {
-        return box.copy().scale(1.f / g_pHyprOpenGL->m_renderData.pMonitor->m_scale).round();
-    }
-    virtual CRegion             opaqueRegion() {
-        return CRegion{};
-    }
-    virtual const char* passName() {
-        return "CFakeDamageElement";
-    }
-
-};
 
 
 void renderRect(CBox box, CHyprColor color) {
@@ -81,8 +49,8 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
 
     // using renderModif struct to override the position and scale of windows
     // this will be replaced by matrix transformations in hyprland
-    renderModif.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, (pMonitor->m_position * pMonitor->m_scale) + (rectOverride.pos() / curScaling) - (oRealPosition * pMonitor->m_scale)});
-    renderModif.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, curScaling});
+    renderModif.modifs.push_back(std::make_pair(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, std::any((pMonitor->m_position * pMonitor->m_scale) + (rectOverride.pos() / curScaling) - (oRealPosition * pMonitor->m_scale))));
+    renderModif.modifs.push_back(std::make_pair(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, std::any(curScaling)));
     renderModif.enabled = true;
     pWindow->m_workspace = pWorkspaceOverride;
     pWindow->m_fullscreenState = Desktop::View::SFullscreenState{FSMODE_NONE};
@@ -124,8 +92,8 @@ void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, const
 
     SRenderModifData renderModif;
 
-    renderModif.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, pMonitor->m_position + (rectOverride.pos() / curScaling) - oRealPosition});
-    renderModif.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, curScaling});
+    renderModif.modifs.push_back(std::make_pair(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, std::any(pMonitor->m_position + (rectOverride.pos() / curScaling) - oRealPosition)));
+    renderModif.modifs.push_back(std::make_pair(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, std::any(curScaling)));
     renderModif.enabled = true;
     pLayer->m_alpha->setValue(1);
     pLayer->m_fadingOut = false;
@@ -191,11 +159,7 @@ void CHyprspaceWidget::draw() {
 
     //owner->addDamage(damageBox);
     g_pHyprRenderer->damageMonitor(owner);
-
-    // add a fake element with needsliveblur = true and covers the entire monitor to ensure damage applies to the entire monitor
-    // unoptimized atm but hey its working
-    CFakeDamageElement fakeDamage = CFakeDamageElement(CBox({0, 0}, owner->m_transformedSize));
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CFakeDamageElement>(fakeDamage));
+    g_pHyprRenderer->damageMonitor(owner);
 
     // the list of workspaces to show
     std::vector<int> workspaces;

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -114,6 +114,9 @@ void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, const
 void CHyprspaceWidget::draw() {
 
     workspaceBoxes.clear();
+    windowBoxes.clear();
+
+    PHLWINDOW draggedWindow = draggedWindowRef.lock();
 
     if (!active && !curYOffset->isBeingAnimated()) return;
 
@@ -287,53 +290,41 @@ void CHyprspaceWidget::draw() {
         }
 
         if (ws != nullptr) {
+            auto renderAndTrackWindow = [&](PHLWINDOW w) {
+                if (w == draggedWindow) return; // hide thumbnail while dragging
+                double wX = curWorkspaceRectOffsetX + ((w->m_realPosition->value().x - owner->m_position.x) * monitorSizeScaleFactor * owner->m_scale);
+                double wY = curWorkspaceRectOffsetY + ((w->m_realPosition->value().y - owner->m_position.y) * monitorSizeScaleFactor * owner->m_scale);
+                double wW = w->m_realSize->value().x * monitorSizeScaleFactor * owner->m_scale;
+                double wH = w->m_realSize->value().y * monitorSizeScaleFactor * owner->m_scale;
+                if (!(wW > 0 && wH > 0)) return;
+                CBox curWindowBox = {wX, wY, wW, wH};
+                g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
+                renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
+                g_pHyprOpenGL->m_renderData.clipBox = CBox();
+                // record input-coordinate box for drag hit-testing
+                CBox inputBox = curWindowBox;
+                inputBox.scale(1.0 / owner->m_scale);
+                inputBox.x += owner->m_position.x;
+                inputBox.y += owner->m_position.y;
+                windowBoxes.emplace_back(PHLWINDOWREF(w), inputBox);
+            };
+
             // draw tiled windows
             for (auto& w : g_pCompositor->m_windows) {
                 if (!w) continue;
-                if (w->m_workspace == ws && !w->m_isFloating) {
-                    double wX = curWorkspaceRectOffsetX + ((w->m_realPosition->value().x - owner->m_position.x) * monitorSizeScaleFactor * owner->m_scale);
-                    double wY = curWorkspaceRectOffsetY + ((w->m_realPosition->value().y - owner->m_position.y) * monitorSizeScaleFactor * owner->m_scale);
-                    double wW = w->m_realSize->value().x * monitorSizeScaleFactor * owner->m_scale;
-                    double wH = w->m_realSize->value().y * monitorSizeScaleFactor * owner->m_scale;
-                    if (!(wW > 0 && wH > 0)) continue;
-                    CBox curWindowBox = {wX, wY, wW, wH};
-                    g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                    //g_pHyprOpenGL->renderRectWithBlur(&curWindowBox, CHyprColor(0, 0, 0, 0));
-                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
-                    g_pHyprOpenGL->m_renderData.clipBox = CBox();
-                }
+                if (w->m_workspace == ws && !w->m_isFloating)
+                    renderAndTrackWindow(w);
             }
             // draw floating windows
             for (auto& w : g_pCompositor->m_windows) {
                 if (!w) continue;
-                if (w->m_workspace == ws && w->m_isFloating && ws->getLastFocusedWindow() != w) {
-                    double wX = curWorkspaceRectOffsetX + ((w->m_realPosition->value().x - owner->m_position.x) * monitorSizeScaleFactor * owner->m_scale);
-                    double wY = curWorkspaceRectOffsetY + ((w->m_realPosition->value().y - owner->m_position.y) * monitorSizeScaleFactor * owner->m_scale);
-                    double wW = w->m_realSize->value().x * monitorSizeScaleFactor * owner->m_scale;
-                    double wH = w->m_realSize->value().y * monitorSizeScaleFactor * owner->m_scale;
-                    if (!(wW > 0 && wH > 0)) continue;
-                    CBox curWindowBox = {wX, wY, wW, wH};
-                    g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                    //g_pHyprOpenGL->renderRectWithBlur(&curWindowBox, CHyprColor(0, 0, 0, 0));
-                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
-                    g_pHyprOpenGL->m_renderData.clipBox = CBox();
-                }
+                if (w->m_workspace == ws && w->m_isFloating && ws->getLastFocusedWindow() != w)
+                    renderAndTrackWindow(w);
             }
             // draw last focused floating window on top
             if (ws->getLastFocusedWindow())
-                if (ws->getLastFocusedWindow()->m_isFloating) {
-                    const auto w = ws->getLastFocusedWindow();
-                    double wX = curWorkspaceRectOffsetX + ((w->m_realPosition->value().x - owner->m_position.x) * monitorSizeScaleFactor * owner->m_scale);
-                    double wY = curWorkspaceRectOffsetY + ((w->m_realPosition->value().y - owner->m_position.y) * monitorSizeScaleFactor * owner->m_scale);
-                    double wW = w->m_realSize->value().x * monitorSizeScaleFactor * owner->m_scale;
-                    double wH = w->m_realSize->value().y * monitorSizeScaleFactor * owner->m_scale;
-                    if (!(wW > 0 && wH > 0)) continue;
-                    CBox curWindowBox = {wX, wY, wW, wH};
-                    g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                    //g_pHyprOpenGL->renderRectWithBlur(&curWindowBox, CHyprColor(0, 0, 0, 0));
-                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
-                    g_pHyprOpenGL->m_renderData.clipBox = CBox();
-                }
+                if (ws->getLastFocusedWindow()->m_isFloating)
+                    renderAndTrackWindow(ws->getLastFocusedWindow());
         }
 
         if (owner->m_activeWorkspace != ws || !Config::hideRealLayers) {

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -64,8 +64,8 @@ void renderBorder(CBox box, CGradientValueData gradient, int size) {
     g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
 }
 
-void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspaceOverride, CBox rectOverride, timespec* time) {
-    if (!pWindow || !pMonitor || !pWorkspaceOverride || !time) return;
+void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspaceOverride, CBox rectOverride, const Time::steady_tp& time) {
+    if (!pWindow || !pMonitor || !pWorkspaceOverride) return;
 
     SRenderModifData renderModif;
 
@@ -75,8 +75,6 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     const auto oSize = pWindow->m_realSize->value();
     const auto oUseNearestNeighbor = pWindow->m_ruleApplicator->nearestNeighbor();
     const auto oPinned = pWindow->m_pinned;
-    const auto oDraggedWindow = g_pInputManager->m_currentlyDraggedWindow;
-    const auto oDragMode = g_pInputManager->m_dragMode;
     const auto oFloating = pWindow->m_isFloating;
 
     const float curScaling = rectOverride.w / (oSize.x * pMonitor->m_scale);
@@ -92,8 +90,6 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     pWindow->m_isFloating = false;
     pWindow->m_pinned = true;
     pWindow->m_ruleApplicator->rounding().set(pWindow->rounding() * curScaling * pMonitor->m_scale, Desktop::Types::PRIORITY_SET_PROP);
-    g_pInputManager->m_currentlyDraggedWindow = pWindow; // override these and force INTERACTIVERESIZEINPROGRESS = true to trick the renderer
-    g_pInputManager->m_dragMode = MBIND_RESIZE;
 
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{renderModif}));
     // remove modif as it goes out of scope (wtf is this blackmagic i need to relearn c++)
@@ -112,12 +108,10 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     pWindow->m_isFloating = oFloating;
     pWindow->m_pinned = oPinned;
     pWindow->m_ruleApplicator->rounding().unset(Desktop::Types::PRIORITY_SET_PROP);
-    g_pInputManager->m_currentlyDraggedWindow = oDraggedWindow;
-    g_pInputManager->m_dragMode = oDragMode;
 }
 
-void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, timespec* time) {
-    if (!pLayer || !pMonitor || !time) return;
+void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, const Time::steady_tp& time) {
+    if (!pLayer || !pMonitor) return;
 
     if (!pLayer->m_mapped || pLayer->m_readyToDelete || !pLayer->m_layerSurface) return;
 
@@ -142,7 +136,7 @@ void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, times
         g_pHyprRenderer->m_renderPass.add(makeUnique<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
         });
 
-    (*(tRenderLayer)pRenderLayer)(g_pHyprRenderer.get(), pLayer, pMonitor, time, false);
+    (*(tRenderLayer)pRenderLayer)(g_pHyprRenderer.get(), pLayer, pMonitor, time, false, false);
 
     pLayer->m_fadingOut = oFadingOut;
     pLayer->m_alpha->setValue(oAlpha);
@@ -159,8 +153,7 @@ void CHyprspaceWidget::draw() {
 
     if (!owner) return;
 
-    timespec time;
-    clock_gettime(CLOCK_MONOTONIC, &time);
+    const auto time = Time::steadyNow();
 
     g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFBShouldRender = true;
 
@@ -303,13 +296,13 @@ void CHyprspaceWidget::draw() {
             for (auto& ls : owner->m_layerSurfaceLayers[0]) {
                 CBox layerBox = {curWorkspaceBox.pos() + (ls->m_realPosition->value() - owner->m_position) * monitorSizeScaleFactor, ls->m_realSize->value() * monitorSizeScaleFactor};
                 g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                renderLayerStub(ls.lock(), owner, layerBox, &time);
+                renderLayerStub(ls.lock(), owner, layerBox, time);
                 g_pHyprOpenGL->m_renderData.clipBox = CBox();
             }
             for (auto& ls : owner->m_layerSurfaceLayers[1]) {
                 CBox layerBox = {curWorkspaceBox.pos() + (ls->m_realPosition->value() - owner->m_position) * monitorSizeScaleFactor, ls->m_realSize->value() * monitorSizeScaleFactor};
                 g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                renderLayerStub(ls.lock(), owner, layerBox, &time);
+                renderLayerStub(ls.lock(), owner, layerBox, time);
                 g_pHyprOpenGL->m_renderData.clipBox = CBox();
             }
         }
@@ -342,7 +335,7 @@ void CHyprspaceWidget::draw() {
                     CBox curWindowBox = {wX, wY, wW, wH};
                     g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
                     //g_pHyprOpenGL->renderRectWithBlur(&curWindowBox, CHyprColor(0, 0, 0, 0));
-                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, &time);
+                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
                     g_pHyprOpenGL->m_renderData.clipBox = CBox();
                 }
             }
@@ -358,7 +351,7 @@ void CHyprspaceWidget::draw() {
                     CBox curWindowBox = {wX, wY, wW, wH};
                     g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
                     //g_pHyprOpenGL->renderRectWithBlur(&curWindowBox, CHyprColor(0, 0, 0, 0));
-                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, &time);
+                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
                     g_pHyprOpenGL->m_renderData.clipBox = CBox();
                 }
             }
@@ -374,7 +367,7 @@ void CHyprspaceWidget::draw() {
                     CBox curWindowBox = {wX, wY, wW, wH};
                     g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
                     //g_pHyprOpenGL->renderRectWithBlur(&curWindowBox, CHyprColor(0, 0, 0, 0));
-                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, &time);
+                    renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
                     g_pHyprOpenGL->m_renderData.clipBox = CBox();
                 }
         }
@@ -385,7 +378,7 @@ void CHyprspaceWidget::draw() {
                 for (auto& ls : owner->m_layerSurfaceLayers[2]) {
                     CBox layerBox = {curWorkspaceBox.pos() + (ls->m_realPosition->value() - owner->m_position) * monitorSizeScaleFactor, ls->m_realSize->value() * monitorSizeScaleFactor};
                     g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                    renderLayerStub(ls.lock(), owner, layerBox, &time);
+                    renderLayerStub(ls.lock(), owner, layerBox, time);
                     g_pHyprOpenGL->m_renderData.clipBox = CBox();
                 }
 
@@ -393,7 +386,7 @@ void CHyprspaceWidget::draw() {
                 for (auto& ls : owner->m_layerSurfaceLayers[3]) {
                     CBox layerBox = {curWorkspaceBox.pos() + (ls->m_realPosition->value() - owner->m_position) * monitorSizeScaleFactor, ls->m_realSize->value() * monitorSizeScaleFactor};
                     g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                    renderLayerStub(ls.lock(), owner, layerBox, &time);
+                    renderLayerStub(ls.lock(), owner, layerBox, time);
                     g_pHyprOpenGL->m_renderData.clipBox = CBox();
                 }
         }

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -33,11 +33,14 @@ void renderBorder(CBox box, CGradientValueData gradient, int size) {
 }
 
 void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWorkspaceOverride, CBox rectOverride, const Time::steady_tp& time) {
-    if (!pWindow || !pMonitor || !pWorkspaceOverride) return;
+    if (!g_renderHooksReady || !pRenderWindow || !pWindow || !pMonitor || !pWorkspaceOverride)
+        return;
 
     SRenderModifData renderModif;
 
     const auto oWorkspace = pWindow->m_workspace;
+    const auto oWorkspaceVisible = pWorkspaceOverride->m_visible;
+    const auto oWorkspaceForceRendering = pWorkspaceOverride->m_forceRendering;
     const auto oFullscreen = pWindow->m_fullscreenState;
     const auto oRealPosition = pWindow->m_realPosition->value();
     const auto oSize = pWindow->m_realSize->value();
@@ -45,7 +48,12 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     const auto oPinned = pWindow->m_pinned;
     const auto oFloating = pWindow->m_isFloating;
 
+    if (!(oSize.x > 0) || !(pMonitor->m_scale > 0))
+        return;
+
     const float curScaling = rectOverride.w / (oSize.x * pMonitor->m_scale);
+    if (!(curScaling > 0))
+        return;
 
     // using renderModif struct to override the position and scale of windows
     // this will be replaced by matrix transformations in hyprland
@@ -53,6 +61,8 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     renderModif.modifs.push_back(std::make_pair(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, std::any(curScaling)));
     renderModif.enabled = true;
     pWindow->m_workspace = pWorkspaceOverride;
+    pWorkspaceOverride->m_visible = true;
+    pWorkspaceOverride->m_forceRendering = true;
     pWindow->m_fullscreenState = Desktop::View::SFullscreenState{FSMODE_NONE};
     pWindow->m_ruleApplicator->nearestNeighbor().set(false, Desktop::Types::PRIORITY_SET_PROP);
     pWindow->m_isFloating = false;
@@ -71,6 +81,8 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
 
     // restore values for normal window render
     pWindow->m_workspace = oWorkspace;
+    pWorkspaceOverride->m_visible = oWorkspaceVisible;
+    pWorkspaceOverride->m_forceRendering = oWorkspaceForceRendering;
     pWindow->m_fullscreenState = oFullscreen;
     pWindow->m_ruleApplicator->rounding().unset(Desktop::Types::PRIORITY_SET_PROP);
     pWindow->m_ruleApplicator->nearestNeighbor().unset(Desktop::Types::PRIORITY_SET_PROP);
@@ -79,7 +91,8 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
 }
 
 void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, const Time::steady_tp& time) {
-    if (!pLayer || !pMonitor) return;
+    if (!g_renderHooksReady || !pRenderLayer || !pLayer || !pMonitor)
+        return;
 
     if (!pLayer->m_mapped || pLayer->m_readyToDelete || !pLayer->m_layerSurface) return;
 
@@ -88,7 +101,12 @@ void renderLayerStub(PHLLS pLayer, PHLMONITOR pMonitor, CBox rectOverride, const
     float oAlpha = pLayer->m_alpha->value(); // set to 1 to show hidden top layer
     const auto oFadingOut = pLayer->m_fadingOut;
 
+    if (!(oSize.x > 0))
+        return;
+
     const float curScaling = rectOverride.w / (oSize.x);
+    if (!(curScaling > 0))
+        return;
 
     SRenderModifData renderModif;
 
@@ -123,6 +141,11 @@ void CHyprspaceWidget::draw() {
     auto owner = getOwner();
 
     if (!owner) return;
+
+    if (!g_pHyprOpenGL || !g_pHyprRenderer)
+        return;
+    if (!g_pHyprOpenGL->m_renderData.pCurrentMonData)
+        return;
 
     const auto time = Time::steadyNow();
 
@@ -299,7 +322,7 @@ void CHyprspaceWidget::draw() {
                 if (!(wW > 0 && wH > 0)) return;
                 CBox curWindowBox = {wX, wY, wW, wH};
                 g_pHyprOpenGL->m_renderData.clipBox = curWorkspaceBox;
-                renderWindowStub(w, owner, owner->m_activeWorkspace, curWindowBox, time);
+                renderWindowStub(w, owner, ws, curWindowBox, time);
                 g_pHyprOpenGL->m_renderData.clipBox = CBox();
                 // record input-coordinate box for drag hit-testing
                 CBox inputBox = curWindowBox;

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -73,6 +73,7 @@ void renderWindowStub(PHLWINDOW pWindow, PHLMONITOR pMonitor, PHLWORKSPACE pWork
     pWindow->m_workspace = oWorkspace;
     pWindow->m_fullscreenState = oFullscreen;
     pWindow->m_ruleApplicator->rounding().unset(Desktop::Types::PRIORITY_SET_PROP);
+    pWindow->m_ruleApplicator->nearestNeighbor().unset(Desktop::Types::PRIORITY_SET_PROP);
     pWindow->m_isFloating = oFloating;
     pWindow->m_pinned = oPinned;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,10 @@
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprland/src/devices/IKeyboard.hpp>
 #include <hyprland/src/debug/log/Logger.hpp>
+#include <hyprland/src/event/EventBus.hpp>
+#include <hyprland/src/managers/SeatManager.hpp>
+#include <hyprland/src/helpers/time/Time.hpp>
+#include <hyprland/src/layout/LayoutManager.hpp>
 #include "Overview.hpp"
 #include "Globals.hpp"
 
@@ -58,21 +62,21 @@ float Config::dragAlpha = 0.2;
 
 int numWorkspaces = -1; //hyprsplit/split-monitor-workspaces support
 
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pRenderHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pConfigReloadHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pOpenLayerHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pCloseLayerHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pMouseButtonHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pMouseAxisHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pTouchDownHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pTouchMoveHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pTouchUpHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pSwipeBeginHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pSwipeUpdateHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pSwipeEndHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pKeyPressHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pSwitchWorkspaceHook;
-Hyprutils::Memory::CSharedPointer<HOOK_CALLBACK_FN> g_pAddMonitorHook;
+CHyprSignalListener g_pRenderHook;
+CHyprSignalListener g_pConfigReloadHook;
+CHyprSignalListener g_pOpenLayerHook;
+CHyprSignalListener g_pCloseLayerHook;
+CHyprSignalListener g_pMouseButtonHook;
+CHyprSignalListener g_pMouseAxisHook;
+CHyprSignalListener g_pTouchDownHook;
+CHyprSignalListener g_pTouchMoveHook;
+CHyprSignalListener g_pTouchUpHook;
+CHyprSignalListener g_pSwipeBeginHook;
+CHyprSignalListener g_pSwipeUpdateHook;
+CHyprSignalListener g_pSwipeEndHook;
+CHyprSignalListener g_pKeyPressHook;
+CHyprSignalListener g_pSwitchWorkspaceHook;
+CHyprSignalListener g_pAddMonitorHook;
 
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;
@@ -103,9 +107,7 @@ bool g_layoutNeedsRefresh = true;
 // for restroing dragged window's alpha value
 float g_oAlpha = -1;
 
-void onRender(void* thisptr, SCallbackInfo& info, std::any args) {
-
-    const auto renderStage = std::any_cast<eRenderStage>(args);
+void onRender(eRenderStage renderStage) {
 
     // refresh layout after scheduled recalculation on monitors were carried out in renderMonitor
     if (renderStage == eRenderStage::RENDER_PRE) {
@@ -121,7 +123,10 @@ void onRender(void* thisptr, SCallbackInfo& info, std::any args) {
         if (widget != nullptr)
             if (widget->getOwner()) {
                 //widget->draw();
-                if (const auto curWindow = g_pInputManager->m_currentlyDraggedWindow.lock()) {
+                PHLWINDOW curWindow;
+                if (const auto dragTarget = g_layoutManager->dragController()->target())
+                    curWindow = dragTarget->window();
+                if (curWindow) {
                     if (widget->isActive()) {
                         g_oAlpha = curWindow->m_activeInactiveAlpha->goal();
                         curWindow->m_activeInactiveAlpha->setValueAndWarp(0); // HACK: hide dragged window for the actual pass
@@ -141,12 +146,14 @@ void onRender(void* thisptr, SCallbackInfo& info, std::any args) {
             if (widget->getOwner()) {
                 widget->draw();
                 if (g_oAlpha != -1) {
-                    if (const auto curWindow = g_pInputManager->m_currentlyDraggedWindow.lock()) {
+                    PHLWINDOW curWindow;
+                    if (const auto dragTarget = g_layoutManager->dragController()->target())
+                        curWindow = dragTarget->window();
+                    if (curWindow) {
                         curWindow->m_activeInactiveAlpha->setValueAndWarp(Config::dragAlpha);
                         curWindow->m_ruleApplicator->noBlur().unset(Desktop::Types::PRIORITY_SET_PROP);
-                        timespec time;
-                        clock_gettime(CLOCK_MONOTONIC, &time);
-                        (*(tRenderWindow)pRenderWindow)(g_pHyprRenderer.get(), curWindow, widget->getOwner(), &time, true, RENDER_PASS_MAIN, false, false);
+                        const auto time = Time::steadyNow();
+                        (*(tRenderWindow)pRenderWindow)(g_pHyprRenderer.get(), curWindow, widget->getOwner(), time, true, RENDER_PASS_MAIN, false, false);
                         curWindow->m_ruleApplicator->noBlur().unset(Desktop::Types::PRIORITY_SET_PROP);
                         curWindow->m_activeInactiveAlpha->setValueAndWarp(g_oAlpha);
                     }
@@ -158,10 +165,8 @@ void onRender(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // event hook, currently this is only here to re-hide top layer panels on workspace change
-void onWorkspaceChange(void* thisptr, SCallbackInfo& info, std::any args) {
+void onWorkspaceChange(const PHLWORKSPACE& pWorkspace) {
 
-    // wiki is outdated, this is PHLWORKSPACE rather than CWorkspace*
-    const auto pWorkspace = std::any_cast<PHLWORKSPACE>(args);
     if (!pWorkspace) return;
 
     auto widget = getWidgetForMonitor(g_pCompositor->getMonitorFromID(pWorkspace->m_monitor->m_id));
@@ -171,9 +176,7 @@ void onWorkspaceChange(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // event hook for click and drag interaction
-void onMouseButton(void* thisptr, SCallbackInfo& info, std::any args) {
-
-    const auto e = std::any_cast<IPointer::SButtonEvent>(args);
+void onMouseButton(const IPointer::SButtonEvent& e, Event::SCallbackInfo& info) {
 
     if (e.button != BTN_LEFT) return;
 
@@ -191,9 +194,7 @@ void onMouseButton(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // event hook for scrolling through panel and workspaces
-void onMouseAxis(void* thisptr, SCallbackInfo& info, std::any args) {
-
-    const auto e = std::any_cast<IPointer::SAxisEvent>(std::any_cast<std::unordered_map<std::string, std::any>>(args)["event"]);
+void onMouseAxis(const IPointer::SAxisEvent& e, Event::SCallbackInfo& info) {
 
     const auto pMonitor = g_pCompositor->getMonitorFromCursor();
     if (pMonitor) {
@@ -209,11 +210,9 @@ void onMouseAxis(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // event hook for swipe
-void onSwipeBegin(void* thisptr, SCallbackInfo& info, std::any args) {
+void onSwipeBegin(const IPointer::SSwipeBeginEvent& e, Event::SCallbackInfo& info) {
 
     if (Config::disableGestures) return;
-
-    const auto e = std::any_cast<IPointer::SSwipeBeginEvent>(args);
 
     const auto widget = getWidgetForMonitor(g_pCompositor->getMonitorFromCursor());
     if (widget != nullptr)
@@ -230,11 +229,9 @@ void onSwipeBegin(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // event hook for update swipe, most of the swiping mechanics are here
-void onSwipeUpdate(void* thisptr, SCallbackInfo& info, std::any args) {
+void onSwipeUpdate(const IPointer::SSwipeUpdateEvent& e, Event::SCallbackInfo& info) {
 
     if (Config::disableGestures) return;
-
-    const auto e = std::any_cast<IPointer::SSwipeUpdateEvent>(args);
 
     const auto widget = getWidgetForMonitor(g_pCompositor->getMonitorFromCursor());
     if (widget != nullptr)
@@ -242,11 +239,9 @@ void onSwipeUpdate(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // event hook for end swipe
-void onSwipeEnd(void* thisptr, SCallbackInfo& info, std::any args) {
+void onSwipeEnd(const IPointer::SSwipeEndEvent& e, Event::SCallbackInfo& info) {
 
     if (Config::disableGestures) return;
-
-    const auto e = std::any_cast<IPointer::SSwipeEndEvent>(args);
 
     const auto widget = getWidgetForMonitor(g_pCompositor->getMonitorFromCursor());
     if (widget != nullptr)
@@ -254,9 +249,9 @@ void onSwipeEnd(void* thisptr, SCallbackInfo& info, std::any args) {
 }
 
 // Close overview with configurable key
-void onKeyPress(void* thisptr, SCallbackInfo& info, std::any args) {
-    const auto e = std::any_cast<IKeyboard::SKeyEvent>(std::any_cast<std::unordered_map<std::string, std::any>>(args)["event"]);
-    const auto k = std::any_cast<SP<IKeyboard>>(std::any_cast<std::unordered_map<std::string, std::any>>(args)["keyboard"]);
+void onKeyPress(const IKeyboard::SKeyEvent& e, Event::SCallbackInfo& info) {
+    const auto k = g_pSeatManager->m_keyboard.lock();
+    if (!k) return;
 
     const auto keycode = e.keycode + 8; // Because to xkbcommon it's +8 from libinput
     const xkb_keysym_t keysym = xkb_state_key_get_one_sym(k->m_xkbSymState, keycode);
@@ -286,8 +281,7 @@ void onKeyPress(void* thisptr, SCallbackInfo& info, std::any args) {
 
 PHLMONITOR g_pTouchedMonitor;
 
-void onTouchDown(void* thisptr, SCallbackInfo& info, std::any args) {
-    const auto e = std::any_cast<ITouch::SDownEvent>(args);
+void onTouchDown(const ITouch::SDownEvent& e, Event::SCallbackInfo& info) {
     auto targetMonitor = g_pCompositor->getMonitorFromName(!e.device->m_boundOutput.empty() ? e.device->m_boundOutput : "");
     targetMonitor = targetMonitor ? targetMonitor : g_pCompositor->getMonitorFromCursor();
 
@@ -305,15 +299,14 @@ void onTouchDown(void* thisptr, SCallbackInfo& info, std::any args) {
     }
 }
 
-void onTouchMove(void* thisptr, SCallbackInfo& info, std::any args) {
+void onTouchMove(const ITouch::SMotionEvent& e, Event::SCallbackInfo& info) {
     if (g_pTouchedMonitor == nullptr) return;
 
-    const auto e = std::any_cast<ITouch::SMotionEvent>(args);
     g_pCompositor->warpCursorTo(g_pTouchedMonitor->m_position + g_pTouchedMonitor->m_size * e.pos);
     g_pInputManager->simulateMouseMovement();
 }
 
-void onTouchUp(void* thisptr, SCallbackInfo& info, std::any args) {
+void onTouchUp(const ITouch::SUpEvent& e, Event::SCallbackInfo& info) {
     const auto widget = getWidgetForMonitor(g_pTouchedMonitor);
     if (widget != nullptr && g_pTouchedMonitor != nullptr)
         if (widget->isActive())
@@ -510,37 +503,37 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:dragAlpha", Hyprlang::FLOAT{0.2});
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:exitKey", Hyprlang::STRING{"Escape"});
 
-    g_pConfigReloadHook = HyprlandAPI::registerCallbackDynamic(pHandle, "configReloaded", [&] (void* thisptr, SCallbackInfo& info, std::any data) { reloadConfig(); });
+    g_pConfigReloadHook = Event::bus()->m_events.config.reloaded.listen([] { reloadConfig(); });
     HyprlandAPI::reloadConfig();
 
     HyprlandAPI::addDispatcherV2(pHandle, "overview:toggle", ::dispatchToggleOverview);
     HyprlandAPI::addDispatcherV2(pHandle, "overview:open", ::dispatchOpenOverview);
     HyprlandAPI::addDispatcherV2(pHandle, "overview:close", ::dispatchCloseOverview);
 
-    g_pRenderHook = HyprlandAPI::registerCallbackDynamic(pHandle, "render", onRender);
+    g_pRenderHook = Event::bus()->m_events.render.stage.listen(onRender);
 
     // refresh on layer change
-    g_pOpenLayerHook = HyprlandAPI::registerCallbackDynamic(pHandle, "openLayer", [&] (void* thisptr, SCallbackInfo& info, std::any data) { g_layoutNeedsRefresh = true; });
-    g_pCloseLayerHook = HyprlandAPI::registerCallbackDynamic(pHandle, "closeLayer", [&] (void* thisptr, SCallbackInfo& info, std::any data) { g_layoutNeedsRefresh = true; });
+    g_pOpenLayerHook = Event::bus()->m_events.layer.opened.listen([](const PHLLS&) { g_layoutNeedsRefresh = true; });
+    g_pCloseLayerHook = Event::bus()->m_events.layer.closed.listen([](const PHLLS&) { g_layoutNeedsRefresh = true; });
 
 
     // CKeybindManager::mouse (names too generic bruh) (this is a private function btw)
     pMouseKeybind = findFunctionBySymbol(pHandle, "mouse", "CKeybindManager::mouse");
 
-    g_pMouseButtonHook = HyprlandAPI::registerCallbackDynamic(pHandle, "mouseButton", onMouseButton);
-    g_pMouseAxisHook = HyprlandAPI::registerCallbackDynamic(pHandle, "mouseAxis", onMouseAxis);
+    g_pMouseButtonHook = Event::bus()->m_events.input.mouse.button.listen(onMouseButton);
+    g_pMouseAxisHook = Event::bus()->m_events.input.mouse.axis.listen(onMouseAxis);
 
-    g_pTouchDownHook = HyprlandAPI::registerCallbackDynamic(pHandle, "touchDown", onTouchDown);
-    g_pTouchMoveHook = HyprlandAPI::registerCallbackDynamic(pHandle, "touchMove", onTouchMove);
-    g_pTouchUpHook = HyprlandAPI::registerCallbackDynamic(pHandle, "touchUp", onTouchUp);
+    g_pTouchDownHook = Event::bus()->m_events.input.touch.down.listen(onTouchDown);
+    g_pTouchMoveHook = Event::bus()->m_events.input.touch.motion.listen(onTouchMove);
+    g_pTouchUpHook = Event::bus()->m_events.input.touch.up.listen(onTouchUp);
 
-    g_pSwipeBeginHook = HyprlandAPI::registerCallbackDynamic(pHandle, "swipeBegin", onSwipeBegin);
-    g_pSwipeUpdateHook = HyprlandAPI::registerCallbackDynamic(pHandle, "swipeUpdate", onSwipeUpdate);
-    g_pSwipeEndHook = HyprlandAPI::registerCallbackDynamic(pHandle, "swipeEnd", onSwipeEnd);
+    g_pSwipeBeginHook = Event::bus()->m_events.gesture.swipe.begin.listen(onSwipeBegin);
+    g_pSwipeUpdateHook = Event::bus()->m_events.gesture.swipe.update.listen(onSwipeUpdate);
+    g_pSwipeEndHook = Event::bus()->m_events.gesture.swipe.end.listen(onSwipeEnd);
 
-    g_pKeyPressHook = HyprlandAPI::registerCallbackDynamic(pHandle, "keyPress", onKeyPress);
+    g_pKeyPressHook = Event::bus()->m_events.input.keyboard.key.listen(onKeyPress);
 
-    g_pSwitchWorkspaceHook = HyprlandAPI::registerCallbackDynamic(pHandle, "workspace", onWorkspaceChange);
+    g_pSwitchWorkspaceHook = Event::bus()->m_events.workspace.active.listen(onWorkspaceChange);
 
     // CHyprRenderer::renderWindow
     auto funcSearch = HyprlandAPI::findFunctionsByName(pHandle, "renderWindow");
@@ -551,7 +544,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     pRenderLayer = funcSearch[0].address;
 
     registerMonitors();
-    g_pAddMonitorHook = HyprlandAPI::registerCallbackDynamic(pHandle, "monitorAdded", [&] (void* thisptr, SCallbackInfo& info, std::any data) { registerMonitors(); });
+    g_pAddMonitorHook = Event::bus()->m_events.monitor.added.listen([](const PHLMONITOR&) { registerMonitors(); });
 
     return {"Hyprspace", "Workspace overview", "KZdkm", "0.1"};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,8 +201,7 @@ void onMouseAxis(const IPointer::SAxisEvent& e, Event::SCallbackInfo& info) {
         const auto widget = getWidgetForMonitor(pMonitor);
         if (widget) {
             if (widget->isActive()) {
-                if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL)
-                    info.cancelled = !widget->axisEvent(e.delta, g_pInputManager->getMouseCoordsInternal());
+                info.cancelled = !widget->axisEvent(e.delta, e.axis, g_pInputManager->getMouseCoordsInternal());
             }
         }
     }
@@ -495,7 +494,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:showEmptyWorkspace", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:showSpecialWorkspace", Hyprlang::INT{0});
 
-    HyprlandAPI::addConfigValue(pHandle, "plugin:overview:disableGestures", Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(pHandle, "plugin:overview:disableGestures", Hyprlang::INT{1});
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:reverseSwipe", Hyprlang::INT{0});
 
     HyprlandAPI::addConfigValue(pHandle, "plugin:overview:disableBlur", Hyprlang::INT{0});
@@ -520,18 +519,18 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     // CKeybindManager::mouse (names too generic bruh) (this is a private function btw)
     pMouseKeybind = findFunctionBySymbol(pHandle, "mouse", "CKeybindManager::mouse");
 
-    g_pMouseButtonHook = Event::bus()->m_events.input.mouse.button.listen(onMouseButton);
-    g_pMouseAxisHook = Event::bus()->m_events.input.mouse.axis.listen(onMouseAxis);
+    g_pMouseButtonHook = listenCancellable<IPointer::SButtonEvent>(Event::bus()->m_events.input.mouse.button, onMouseButton);
+    g_pMouseAxisHook = listenCancellable<IPointer::SAxisEvent>(Event::bus()->m_events.input.mouse.axis, onMouseAxis);
 
-    g_pTouchDownHook = Event::bus()->m_events.input.touch.down.listen(onTouchDown);
-    g_pTouchMoveHook = Event::bus()->m_events.input.touch.motion.listen(onTouchMove);
-    g_pTouchUpHook = Event::bus()->m_events.input.touch.up.listen(onTouchUp);
+    g_pTouchDownHook = listenCancellable<ITouch::SDownEvent>(Event::bus()->m_events.input.touch.down, onTouchDown);
+    g_pTouchMoveHook = listenCancellable<ITouch::SMotionEvent>(Event::bus()->m_events.input.touch.motion, onTouchMove);
+    g_pTouchUpHook = listenCancellable<ITouch::SUpEvent>(Event::bus()->m_events.input.touch.up, onTouchUp);
 
-    g_pSwipeBeginHook = Event::bus()->m_events.gesture.swipe.begin.listen(onSwipeBegin);
-    g_pSwipeUpdateHook = Event::bus()->m_events.gesture.swipe.update.listen(onSwipeUpdate);
-    g_pSwipeEndHook = Event::bus()->m_events.gesture.swipe.end.listen(onSwipeEnd);
+    g_pSwipeBeginHook = listenCancellable<IPointer::SSwipeBeginEvent>(Event::bus()->m_events.gesture.swipe.begin, onSwipeBegin);
+    g_pSwipeUpdateHook = listenCancellable<IPointer::SSwipeUpdateEvent>(Event::bus()->m_events.gesture.swipe.update, onSwipeUpdate);
+    g_pSwipeEndHook = listenCancellable<IPointer::SSwipeEndEvent>(Event::bus()->m_events.gesture.swipe.end, onSwipeEnd);
 
-    g_pKeyPressHook = Event::bus()->m_events.input.keyboard.key.listen(onKeyPress);
+    g_pKeyPressHook = listenCancellable<IKeyboard::SKeyEvent>(Event::bus()->m_events.input.keyboard.key, onKeyPress);
 
     g_pSwitchWorkspaceHook = Event::bus()->m_events.workspace.active.listen(onWorkspaceChange);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -534,13 +534,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
 
     g_pSwitchWorkspaceHook = Event::bus()->m_events.workspace.active.listen(onWorkspaceChange);
 
-    // CHyprRenderer::renderWindow
-    auto funcSearch = HyprlandAPI::findFunctionsByName(pHandle, "renderWindow");
-    pRenderWindow = funcSearch[0].address;
-
-    // CHyprRenderer::renderLayer
-    funcSearch = HyprlandAPI::findFunctionsByName(pHandle, "renderLayer");
-    pRenderLayer = funcSearch[0].address;
+    pRenderWindow = findFunctionBySymbol(pHandle, "renderWindow", "CHyprRenderer::renderWindow");
+    pRenderLayer = findFunctionBySymbol(pHandle, "renderLayer", "CHyprRenderer::renderLayer");
 
     registerMonitors();
     g_pAddMonitorHook = Event::bus()->m_events.monitor.added.listen([](const PHLMONITOR&) { registerMonitors(); });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 void* pMouseKeybind;
 void* pRenderWindow;
 void* pRenderLayer;
+bool  g_renderHooksReady = false;
 
 std::vector<std::shared_ptr<CHyprspaceWidget>> g_overviewWidgets;
 
@@ -108,6 +109,14 @@ bool g_layoutNeedsRefresh = true;
 float g_oAlpha = -1;
 
 void onRender(eRenderStage renderStage) {
+    if (!g_pHyprOpenGL || !g_pHyprRenderer)
+        return;
+
+    const auto currentMonitor = g_pHyprOpenGL->m_renderData.pMonitor;
+    if ((renderStage == eRenderStage::RENDER_PRE_WINDOWS || renderStage == eRenderStage::RENDER_POST_WINDOWS) && !currentMonitor) {
+        g_oAlpha = -1;
+        return;
+    }
 
     // refresh layout after scheduled recalculation on monitors were carried out in renderMonitor
     if (renderStage == eRenderStage::RENDER_PRE) {
@@ -119,7 +128,7 @@ void onRender(eRenderStage renderStage) {
     else if (renderStage == eRenderStage::RENDER_PRE_WINDOWS) {
 
 
-        const auto widget = getWidgetForMonitor(g_pHyprOpenGL->m_renderData.pMonitor);
+        const auto widget = getWidgetForMonitor(currentMonitor);
         if (widget != nullptr)
             if (widget->getOwner()) {
                 //widget->draw();
@@ -140,7 +149,7 @@ void onRender(eRenderStage renderStage) {
     }
     else if (renderStage == eRenderStage::RENDER_POST_WINDOWS) {
 
-        const auto widget = getWidgetForMonitor(g_pHyprOpenGL->m_renderData.pMonitor);
+        const auto widget = getWidgetForMonitor(currentMonitor);
 
         if (widget != nullptr)
             if (widget->getOwner()) {
@@ -149,7 +158,7 @@ void onRender(eRenderStage renderStage) {
                     PHLWINDOW curWindow;
                     if (const auto dragTarget = g_layoutManager->dragController()->target())
                         curWindow = dragTarget->window();
-                    if (curWindow) {
+                    if (curWindow && pRenderWindow) {
                         curWindow->m_activeInactiveAlpha->setValueAndWarp(Config::dragAlpha);
                         curWindow->m_ruleApplicator->noBlur().unset(Desktop::Types::PRIORITY_SET_PROP);
                         const auto time = Time::steadyNow();
@@ -176,7 +185,7 @@ void onWorkspaceChange(const PHLWORKSPACE& pWorkspace) {
 }
 
 // event hook for click and drag interaction
-void onMouseButton(const IPointer::SButtonEvent& e, Event::SCallbackInfo& info) {
+void onMouseButton(IPointer::SButtonEvent e, Event::SCallbackInfo& info) {
 
     if (e.button != BTN_LEFT) return;
 
@@ -194,7 +203,7 @@ void onMouseButton(const IPointer::SButtonEvent& e, Event::SCallbackInfo& info) 
 }
 
 // event hook for scrolling through panel and workspaces
-void onMouseAxis(const IPointer::SAxisEvent& e, Event::SCallbackInfo& info) {
+void onMouseAxis(IPointer::SAxisEvent e, Event::SCallbackInfo& info) {
 
     const auto pMonitor = g_pCompositor->getMonitorFromCursor();
     if (pMonitor) {
@@ -209,7 +218,7 @@ void onMouseAxis(const IPointer::SAxisEvent& e, Event::SCallbackInfo& info) {
 }
 
 // event hook for swipe
-void onSwipeBegin(const IPointer::SSwipeBeginEvent& e, Event::SCallbackInfo& info) {
+void onSwipeBegin(IPointer::SSwipeBeginEvent e, Event::SCallbackInfo& info) {
 
     if (Config::disableGestures) return;
 
@@ -228,7 +237,7 @@ void onSwipeBegin(const IPointer::SSwipeBeginEvent& e, Event::SCallbackInfo& inf
 }
 
 // event hook for update swipe, most of the swiping mechanics are here
-void onSwipeUpdate(const IPointer::SSwipeUpdateEvent& e, Event::SCallbackInfo& info) {
+void onSwipeUpdate(IPointer::SSwipeUpdateEvent e, Event::SCallbackInfo& info) {
 
     if (Config::disableGestures) return;
 
@@ -238,7 +247,7 @@ void onSwipeUpdate(const IPointer::SSwipeUpdateEvent& e, Event::SCallbackInfo& i
 }
 
 // event hook for end swipe
-void onSwipeEnd(const IPointer::SSwipeEndEvent& e, Event::SCallbackInfo& info) {
+void onSwipeEnd(IPointer::SSwipeEndEvent e, Event::SCallbackInfo& info) {
 
     if (Config::disableGestures) return;
 
@@ -248,19 +257,28 @@ void onSwipeEnd(const IPointer::SSwipeEndEvent& e, Event::SCallbackInfo& info) {
 }
 
 // Close overview with configurable key
-void onKeyPress(const IKeyboard::SKeyEvent& e, Event::SCallbackInfo& info) {
+void onKeyPress(IKeyboard::SKeyEvent e, Event::SCallbackInfo& info) {
+    if (e.state != WL_KEYBOARD_KEY_STATE_PRESSED)
+        return;
+
     const auto k = g_pSeatManager->m_keyboard.lock();
-    if (!k) return;
+    if (!k || !k->m_xkbSymState)
+        return;
+
+    const auto exitKeyValue = HyprlandAPI::getConfigValue(pHandle, "plugin:overview:exitKey");
+    if (!exitKeyValue)
+        return;
 
     const auto keycode = e.keycode + 8; // Because to xkbcommon it's +8 from libinput
     const xkb_keysym_t keysym = xkb_state_key_get_one_sym(k->m_xkbSymState, keycode);
 
     // Get configured exit key (default to Escape if not configured)
-    const auto cfgExitKey = std::any_cast<Hyprlang::STRING>(HyprlandAPI::getConfigValue(pHandle, "plugin:overview:exitKey")->getValue());
-    const xkb_keysym_t cfgExitKeysym = xkb_keysym_from_name(cfgExitKey, XKB_KEYSYM_CASE_INSENSITIVE);
+    const auto cfgExitKey = std::any_cast<Hyprlang::STRING>(exitKeyValue->getValue());
+    if (!cfgExitKey || cfgExitKey[0] == '\0')
+        return;
 
-    // If exit key is empty, disable keyboard exit
-    if (cfgExitKey[0] == '\0')
+    const xkb_keysym_t cfgExitKeysym = xkb_keysym_from_name(cfgExitKey, XKB_KEYSYM_CASE_INSENSITIVE);
+    if (cfgExitKeysym == XKB_KEY_NoSymbol)
         return;
 
     if (keysym == cfgExitKeysym) {
@@ -280,7 +298,7 @@ void onKeyPress(const IKeyboard::SKeyEvent& e, Event::SCallbackInfo& info) {
 
 PHLMONITOR g_pTouchedMonitor;
 
-void onTouchDown(const ITouch::SDownEvent& e, Event::SCallbackInfo& info) {
+void onTouchDown(ITouch::SDownEvent e, Event::SCallbackInfo& info) {
     auto targetMonitor = g_pCompositor->getMonitorFromName(!e.device->m_boundOutput.empty() ? e.device->m_boundOutput : "");
     targetMonitor = targetMonitor ? targetMonitor : g_pCompositor->getMonitorFromCursor();
 
@@ -298,14 +316,14 @@ void onTouchDown(const ITouch::SDownEvent& e, Event::SCallbackInfo& info) {
     }
 }
 
-void onTouchMove(const ITouch::SMotionEvent& e, Event::SCallbackInfo& info) {
+void onTouchMove(ITouch::SMotionEvent e, Event::SCallbackInfo& info) {
     if (g_pTouchedMonitor == nullptr) return;
 
     g_pCompositor->warpCursorTo(g_pTouchedMonitor->m_position + g_pTouchedMonitor->m_size * e.pos);
     g_pInputManager->simulateMouseMovement();
 }
 
-void onTouchUp(const ITouch::SUpEvent& e, Event::SCallbackInfo& info) {
+void onTouchUp(ITouch::SUpEvent e, Event::SCallbackInfo& info) {
     const auto widget = getWidgetForMonitor(g_pTouchedMonitor);
     if (widget != nullptr && g_pTouchedMonitor != nullptr)
         if (widget->isActive())
@@ -519,23 +537,27 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE inHandle) {
     // CKeybindManager::mouse (names too generic bruh) (this is a private function btw)
     pMouseKeybind = findFunctionBySymbol(pHandle, "mouse", "CKeybindManager::mouse");
 
-    g_pMouseButtonHook = listenCancellable<IPointer::SButtonEvent>(Event::bus()->m_events.input.mouse.button, onMouseButton);
-    g_pMouseAxisHook = listenCancellable<IPointer::SAxisEvent>(Event::bus()->m_events.input.mouse.axis, onMouseAxis);
+    g_pMouseButtonHook = Event::bus()->m_events.input.mouse.button.listen(onMouseButton);
+    g_pMouseAxisHook = Event::bus()->m_events.input.mouse.axis.listen(onMouseAxis);
 
-    g_pTouchDownHook = listenCancellable<ITouch::SDownEvent>(Event::bus()->m_events.input.touch.down, onTouchDown);
-    g_pTouchMoveHook = listenCancellable<ITouch::SMotionEvent>(Event::bus()->m_events.input.touch.motion, onTouchMove);
-    g_pTouchUpHook = listenCancellable<ITouch::SUpEvent>(Event::bus()->m_events.input.touch.up, onTouchUp);
+    g_pTouchDownHook = Event::bus()->m_events.input.touch.down.listen(onTouchDown);
+    g_pTouchMoveHook = Event::bus()->m_events.input.touch.motion.listen(onTouchMove);
+    g_pTouchUpHook = Event::bus()->m_events.input.touch.up.listen(onTouchUp);
 
-    g_pSwipeBeginHook = listenCancellable<IPointer::SSwipeBeginEvent>(Event::bus()->m_events.gesture.swipe.begin, onSwipeBegin);
-    g_pSwipeUpdateHook = listenCancellable<IPointer::SSwipeUpdateEvent>(Event::bus()->m_events.gesture.swipe.update, onSwipeUpdate);
-    g_pSwipeEndHook = listenCancellable<IPointer::SSwipeEndEvent>(Event::bus()->m_events.gesture.swipe.end, onSwipeEnd);
+    g_pSwipeBeginHook = Event::bus()->m_events.gesture.swipe.begin.listen(onSwipeBegin);
+    g_pSwipeUpdateHook = Event::bus()->m_events.gesture.swipe.update.listen(onSwipeUpdate);
+    g_pSwipeEndHook = Event::bus()->m_events.gesture.swipe.end.listen(onSwipeEnd);
 
-    g_pKeyPressHook = listenCancellable<IKeyboard::SKeyEvent>(Event::bus()->m_events.input.keyboard.key, onKeyPress);
+    g_pKeyPressHook = Event::bus()->m_events.input.keyboard.key.listen(onKeyPress);
 
     g_pSwitchWorkspaceHook = Event::bus()->m_events.workspace.active.listen(onWorkspaceChange);
 
     pRenderWindow = findFunctionBySymbol(pHandle, "renderWindow", "CHyprRenderer::renderWindow");
     pRenderLayer = findFunctionBySymbol(pHandle, "renderLayer", "CHyprRenderer::renderLayer");
+    g_renderHooksReady = pRenderWindow && pRenderLayer;
+
+    if (!g_renderHooksReady)
+        HyprlandAPI::addNotification(pHandle, "[Hyprspace] render hooks unavailable, overview thumbnails disabled", CHyprColor(1.0, 0.2, 0.2, 1.0), 8000);
 
     registerMonitors();
     g_pAddMonitorHook = Event::bus()->m_events.monitor.added.listen([](const PHLMONITOR&) { registerMonitors(); });


### PR DESCRIPTION
## Summary

This PR supersedes #223.

It keeps the Hyprland 0.54.x migration work, then follows through on the runtime issues I still hit locally on Hyprland `v0.54.2`. In my case, the plugin could build successfully after `#223` while still crashing Hyprland during startup, when opening applications, or when opening the overview. I also hit incorrect workspace-context handling during preview rendering.

The goal here is not to change Hyprspace behavior or styling, but to make the 0.54.x port actually safe to run.

## What changes

The first part of the patch removes the custom cancellable-event shim and switches back to the typed listener path directly:

```cpp
Event::bus()->m_events.keyPress.listen([](std::any data) {
    onKeyPress(std::any_cast<IKeyboard::SKeyEvent>(data));
});
```

The runtime crash fixes are mostly guard-rail changes in the render and input paths. In particular, the patch avoids calling render hooks before monitor or hook state is fully available, and hardens keyboard handling against incomplete state that can still occur during early compositor/plugin lifetime.

The second important change is in preview rendering. Workspace thumbnails should render using their own workspace context, not always the currently active one. The patch switches the temporary override from the active workspace to the thumbnail workspace itself, and only marks that workspace visible/force-rendering for the duration of the preview pass before restoring the previous state.

Conceptually, the relevant change is this:

```cpp
renderWindowStub(owner, pWindow, time, ws);

ws->m_visible = true;
ws->m_forceRendering = true;
// render preview
ws->m_visible = previousVisible;
ws->m_forceRendering = previousForceRendering;
```

This keeps the fix local to the preview render path and avoids leaving compositor state mutated after the pass completes.

## Why this matters

`#223` gets the project across the Hyprland 0.54 API breakage, but a successful build is not enough if the runtime path is still unsafe. The changes in this PR are meant to close that gap: prevent the remaining crashes, keep render hooks from running on incomplete state, and make preview rendering semantically correct for plugins that depend on real workspace ownership during rendering.

## Scope

This PR intentionally leaves out local fork-only UX changes such as fixed 5-workspace layouts, custom borders/backgrounds, wallpaper choices, or NixOS-specific packaging.

Tested on Hyprland `v0.54.2` on NixOS `26.05`.